### PR TITLE
Do not require conditions to exist when adding vsets

### DIFF
--- a/vsm-app/pages/programs/[id]/valuesets/search/index.tsx
+++ b/vsm-app/pages/programs/[id]/valuesets/search/index.tsx
@@ -434,8 +434,8 @@ const ValueSets = () => {
     e.preventDefault()
     setAddedValueSetsLoading(true)
 
-    if (!selectedValueSets.length || !selectedConditions.length || !selectedGroupers.length) {
-      const message = 'Select at least one valueset, with an associated condition and group.'
+    if (!selectedValueSets.length || !selectedGroupers.length) {
+      const message = 'Select at least one valueset with an associated group. (Conditions optional)'
       toast.error(message)
       setAddedValueSetsLoading(false)
       return


### PR DESCRIPTION
A 2-liner that makes it so that adding conditions are not required to add VSets to a program

Users indicated they didn't want this because batch uploading often means that they can't set all of the conditions ahead of time