### PR TITLE
remove modal from add grouper page and show progress in button

### DIFF
--- a/vsm-app/components/modals/LoadingModal.tsx
+++ b/vsm-app/components/modals/LoadingModal.tsx
@@ -11,7 +11,7 @@ import {
 import { TextArea } from '../TextArea'
 
 interface ModalInfo {
-  actionType: 'release' | 'publish' | 'clone' | 'grouper-add'
+  actionType: 'release' | 'publish' | 'clone'
   isOpen: boolean
   handleCancelModal: () => void
   handleModalAction: Function
@@ -57,18 +57,6 @@ const modalText = {
     modalLoadingText: (
       <LoadingText>
         Cloning may take up to a minute.
-        <br />
-        Please keep this window open until it completes.
-      </LoadingText>
-    )
-  },
-  'grouper-add': {
-    title: 'Save your Grouper',
-    text: 'Saving your updated grouper ValueSet',
-    actionText: 'Would you like to continue?',
-    modalLoadingText: (
-      <LoadingText>
-        Saving a grouper may take up to a minute.
         <br />
         Please keep this window open until it completes.
       </LoadingText>

--- a/vsm-app/pages/programs/[id]/grouper/index.tsx
+++ b/vsm-app/pages/programs/[id]/grouper/index.tsx
@@ -187,14 +187,6 @@ const AddGrouper = () => {
 
   return (
     <>
-      <LoadingModal
-        isOpen={loading}
-        actionType="grouper-add"
-        program={null}
-        handleCancelModal={() => {}}
-        loading={loading}
-        handleModalAction={() => {}}
-      />
       <FormTitle>Add a Grouper</FormTitle>
       <FormSectionHeader
         itemNum={1}
@@ -275,6 +267,7 @@ const AddGrouper = () => {
           style={{
             fontSize: '150%'
           }}
+          loading={loading}
           text="SUBMIT"
           disabled={submitDisabled}
           onClick={async () => await addGrouper()}


### PR DESCRIPTION
The modal was unnecessary here now when you add a grouper, as there's nothing to confirm

Removed modal (and removed grouper-add logic from modal)
As grouper is being created, loading state is passed to the button to generate loading symbol