### PR TITLE
Aphl 702 valueset data display

### DIFF
--- a/vsm-app/components/ValueSetDetailsTables.tsx
+++ b/vsm-app/components/ValueSetDetailsTables.tsx
@@ -212,7 +212,10 @@ const ValueSetDetailsTables = ({
     if (!textToFind) return defData
 
     if (isGrouperValueSet) {
-      return defData.filter((item: any) => item?.valueSet?.[0]?.toLowerCase().includes(filterDefinitionText.toLowerCase()))
+      return defData.filter((item: any) => (
+        item?.name?.toLowerCase().includes(filterDefinitionText.toLowerCase())
+        || item?.oid?.toLowerCase().includes(filterDefinitionText.toLowerCase())
+      ))
     } else {
       return defData.filter((item: any) => item?.display?.toLowerCase().includes(filterDefinitionText.toLowerCase()))
     }
@@ -255,7 +258,7 @@ const ValueSetDetailsTables = ({
           value={filterDefinitionText}
           onChange={(e) => setFilterDefinitionText(e.target.value)}
           id="filter-definition-table"
-          label="Filter Definitions"
+          label={`Filter ${isGrouperValueSet ? 'by Name or OID' : 'Definitions'}`}
           variant="outlined"
         />
         <DataTable


### PR DESCRIPTION
Grouper Definition columns used to just have references, now has name, oid, canonical
Also updated filter function to work with new data format

<img width="1015" alt="image" src="https://github.com/DBCG/aphl-vsm/assets/8888632/0cccec81-2d1e-414a-bec7-7dedd06e81d7">
