### PR TITLE
handle grouper remove bug

### DIFF
--- a/vsm-app/components/GrouperOverviewTable.tsx
+++ b/vsm-app/components/GrouperOverviewTable.tsx
@@ -78,8 +78,8 @@ const GrouperOverviewTable = ({ grouperLibId, programStatus }: GrouperTable) => 
           type: 'delete_failed',
           message: 'Failed to delete grouper Value Set'
         })
-        setDeleting(false)
       }
+      setDeleting(false)
     },
     [programId]
   )
@@ -173,7 +173,7 @@ const GrouperOverviewTable = ({ grouperLibId, programStatus }: GrouperTable) => 
         onRowClicked={(row: fhir4.ValueSet) => {
           router.push(`/programs/${programId}/valuesets/${row.id}`)
         }}
-        data={groups}
+        data={groups || []}
         pagination
         paginationPerPage={10}
         theme="aphl"

--- a/vsm-app/hooks/useGetGroups.ts
+++ b/vsm-app/hooks/useGetGroups.ts
@@ -28,6 +28,7 @@ const useGetGroups = ({ programId, refreshToggle }: GroupArgs): GroupsResponse =
           const json = await response.json()
           if (json.error) {
             console.error(json.error)
+            setGroups([])
             setGroupsError(`Could not find groups for program with id ${programId}`)
           } else {
             setGroups(json)

--- a/vsm-app/pages/api/programs/[id]/details/valuesets/groups/index.ts
+++ b/vsm-app/pages/api/programs/[id]/details/valuesets/groups/index.ts
@@ -3,6 +3,7 @@ import { fhirCdrClient } from 'fhirClients'
 import { addValueSetToGrouper, removeValueSetFromGrouper } from '@/helpers/valueSetHelpers'
 import handler from '@/helpers/server/handler'
 import { WHITELIST_VALUESET_FIELDS } from '../'
+import logger from '@/helpers/server/logger'
 
 interface GroupInfoItem {
   label: string
@@ -10,58 +11,65 @@ interface GroupInfoItem {
 }
 
 const retrieveGroupSets = async (req: NextApiRequest, res: NextApiResponse): Promise<any> => {
-  let result = []
-  // get all grouper valueSets from within a program
-  const programLibrary = await fhirCdrClient.read({ resourceType: 'Library', id: req.query.id as string })
-
-  const programStatus = programLibrary.status
-
-  const grouperLibraryCanonical = programLibrary?.relatedArtifact?.find(
-    (art: any) => art?.type === 'composed-of' && art?.resource?.includes('/Library/')
-  )?.resource
-
-  const [grouperLibUrl, grouperLibVersion] = grouperLibraryCanonical.split('|')
-
-  let searchParams = {
-    url: grouperLibUrl,
-    version: grouperLibVersion,
-    status: programStatus
-  }
-
-  const grouperLibrarySearchBundle = await fhirCdrClient.search({
-    resourceType: 'Library',
-    searchParams
-  })
-
-  const library: fhir4.Library = grouperLibrarySearchBundle?.entry?.[0]?.resource
-
-  const grouperValueSetCanonicals = library?.relatedArtifact
-    ?.filter((art) => art.type === 'composed-of' && art?.resource?.includes('/ValueSet/'))
-    ?.map((item) => item?.resource) as string[]
-
-  if (grouperValueSetCanonicals?.length) {
-    const grouperValueSetSearchSets = await Promise.all(
-      grouperValueSetCanonicals?.map((canonical: string) => {
-        const [url, version] = canonical.split('|')
-        return fhirCdrClient.search({
-          resourceType: 'ValueSet',
-          searchParams: {
-            url: url,
-            version: version,
-            status: programStatus,
-            '_elements': WHITELIST_VALUESET_FIELDS.join(',')
-          }
+  try {
+    let result = []
+    // get all grouper valueSets from within a program
+    const programLibrary = await fhirCdrClient.read({ resourceType: 'Library', id: req.query.id as string })
+  
+    const programStatus = programLibrary.status
+  
+    const grouperLibraryCanonical = programLibrary?.relatedArtifact?.find(
+      (art: any) => art?.type === 'composed-of' && art?.resource?.includes('/Library/')
+    )?.resource
+  
+    const [grouperLibUrl, grouperLibVersion] = grouperLibraryCanonical.split('|')
+  
+    let searchParams = {
+      url: grouperLibUrl,
+      version: grouperLibVersion,
+      status: programStatus
+    }
+  
+    const grouperLibrarySearchBundle = await fhirCdrClient.search({
+      resourceType: 'Library',
+      searchParams
+    })
+  
+    const library: fhir4.Library = grouperLibrarySearchBundle?.entry?.[0]?.resource
+  
+    const grouperValueSetCanonicals = library?.relatedArtifact
+      ?.filter((art) => art.type === 'composed-of' && art?.resource?.includes('/ValueSet/'))
+      ?.map((item) => item?.resource) as string[]
+  
+    if (grouperValueSetCanonicals?.length) {
+      const grouperValueSetSearchSets = await Promise.all(
+        grouperValueSetCanonicals?.map((canonical: string) => {
+          const [url, version] = canonical.split('|')
+          return fhirCdrClient.search({
+            resourceType: 'ValueSet',
+            searchParams: {
+              url: url,
+              version: version,
+              status: programStatus,
+              '_elements': WHITELIST_VALUESET_FIELDS.join(',')
+            }
+          })
         })
-      })
-    )
+      )
+  
+      const grouperVSets = grouperValueSetSearchSets?.map((bundle) => bundle?.entry?.[0]?.resource)
+      result = grouperVSets
+  
+      return res.status(200).send(result)
+    } else {
+      logger.error(`No groupers found for Program Library ${req.query.id}`)
+      return res.status(200).send([])
+    }
 
-    const grouperVSets = grouperValueSetSearchSets?.map((bundle) => bundle?.entry?.[0]?.resource)
-    result = grouperVSets
-
-    res.status(200).send(result)
-    return
+  } catch (e) {
+    logger.error(e)
+    res.status(400).send({ error: 'get groupers failed' })
   }
-  res.status(400).send({ error: 'get groupers failed' })
 }
 
 const updateGroupSets = async (req: NextApiRequest, res: NextApiResponse): Promise<any> => {


### PR DESCRIPTION
There was an infinite loading issue when all groupers were removed from a program

Programs should be allowed to have 0 groupers, and shouldn't be treated like an error (as it was before)

Added a try/catch block in the route to catch any _real_ errors that might occur