### PR TITLE
simple form reset

### DIFF
--- a/vsm-app/components/ProgramMetadata/index.tsx
+++ b/vsm-app/components/ProgramMetadata/index.tsx
@@ -52,6 +52,7 @@ const ProgramMetadata = ({ handleSubmit, program, editable = true }: ProgramEdit
   const [formTouched, setFormTouched] = useState(false)
   const [enableEditing, setEnableEditing] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const [key, setKey] = useState(1)
 
   const initialErrorState = missingFields({ program, requiredFields })
 
@@ -101,7 +102,7 @@ const ProgramMetadata = ({ handleSubmit, program, editable = true }: ProgramEdit
   }
 
   return (
-    <Form error={Boolean(errorFields.length)}>
+    <Form error={Boolean(errorFields.length)} key={key}>
       <Grid container spacing={2} style={{ maxWidth: '700px' }}>
         <Grid item xs={12} md={4}>
           <SearchInput
@@ -230,6 +231,7 @@ const ProgramMetadata = ({ handleSubmit, program, editable = true }: ProgramEdit
                 type="button"
                 onClick={(e) => {
                   e.preventDefault()
+                  setKey(k => k + 1)
                   setFormTouched(false)
                   setEditedProgram(program)
                   setEnableEditing(false)


### PR DESCRIPTION
I feel silly... I had a branch that fixed this in a more complicated way, but then realized that this was all that was strictly necessary to fix the bug.

The problem was that the form wasn't resetting on cancel. Using a key update rerenders that one component so that it resets the form values with the defaults from the program.