### PR TITLE
small fix to remove unnecessary error on reload

### DIFF
--- a/vsm-app/pages/programs/[id]/grouper/index.tsx
+++ b/vsm-app/pages/programs/[id]/grouper/index.tsx
@@ -74,6 +74,7 @@ const AddGrouper = () => {
     const getProgram = async () => {
       const res = await fetch(`/api/programs?id=${programId}`)
       if (res?.ok) {
+        setError(null)
         const json = await res.json()
         setProgramVersion(json?.programs?.[0]?.version)
       } else {


### PR DESCRIPTION
Error was persisting at the bottom of grouper add form page after hard refresh... this fixes it