### PR TITLE
add manifest language in 2 places, release modal and manifest page

### DIFF
--- a/vsm-app/components/ManifestDescription.tsx
+++ b/vsm-app/components/ManifestDescription.tsx
@@ -1,0 +1,56 @@
+import Accordion from '@mui/material/Accordion'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { AccordionP, AccordionHeading } from './Typography'
+
+interface ManifestDesc {
+  context: 'release-modal' | 'manifest-page'
+}
+
+const ManifestDescription = ({ context }: ManifestDesc) => {
+
+  const accordionStyle = context === 'release-modal' ? {
+    backgroundColor: 'var(--theme-color-transparent)',
+    borderBottom: '2px solid var(--theme-200)'
+  } : { boxShadow: 'none' }
+
+  return (
+    <Accordion style={accordionStyle}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        id='manifest-accordion-header'
+      >
+        <AccordionP style={{ fontSize: '110%', marginBottom: 0 }}>Learn more about manifests</AccordionP>
+      </AccordionSummary>
+      <AccordionDetails>
+        <AccordionHeading style={{ marginTop: 0 }}>
+          What is a Manifest?
+        </AccordionHeading>
+        <AccordionP>
+          When a draft program is released, there is a compilation step where all of the data is aggregated to package up. One of the steps is that ValueSets are expanded so that you can inspect all of the component codes.
+        </AccordionP>  
+        <AccordionP>
+          Pinning a code system version in the manifest tells the ValueSet expansion step that you want the codes to come from a specific version of a given code system.
+        </AccordionP>
+        <AccordionHeading>
+          Do I need to save all versions of code systems I use to the manifest?
+        </AccordionHeading>
+        <AccordionP>
+          No, many programs may not use the manifest section at all. If you do not pin versions for code systems here, the expansions will always default to the latest available version of a code system required by a value set.
+        </AccordionP>
+        <AccordionHeading>
+          Why would anyone need to use a manifest?
+        </AccordionHeading>
+        <AccordionP>
+          At authoring time it is often the case that authors want the program specification to use the latest version of code systems as of the time of publication.
+        </AccordionP>
+        <AccordionP>
+          Sometimes, though, the determination is made that for a given code system a specific version should be used wherever it is referenced in the program specification. To facilitate this explicit "pinning" of a code system, an author can specify here in the manifest which version of the code system should be used.
+        </AccordionP>
+      </AccordionDetails>
+    </Accordion>
+  )
+}
+
+export default ManifestDescription

--- a/vsm-app/components/Typography.tsx
+++ b/vsm-app/components/Typography.tsx
@@ -11,6 +11,26 @@ const PageP = styled(Typography).attrs({
   variant: 'body1'
 })`
   color: var(--theme-300);
+  display: inline-block;
+`
+
+const AccordionP = styled(Typography).attrs({
+  variant: 'body1'
+})`
+  display: block;
+  margin-bottom: .5rem;
+  color: var(--theme-400);
+  max-width: 40rem;
+`
+
+const AccordionHeading = styled(Typography).attrs({
+  variant: 'body1'
+})`
+  display: block;
+  color: var(--theme-400);
+  font-weight: bold;
+  margin-top: 1.5em;
+  margin-bottom: .3em;
 `
 
 const FormErrorText = styled(Typography).attrs({
@@ -22,4 +42,4 @@ const FormErrorText = styled(Typography).attrs({
 `
 
 
-export { PageTitle, PageP, FormErrorText }
+export { PageTitle, PageP, FormErrorText, AccordionP, AccordionHeading }

--- a/vsm-app/components/modals/ReleaseModal.tsx
+++ b/vsm-app/components/modals/ReleaseModal.tsx
@@ -29,6 +29,7 @@ import { searchAvailableUpdates, updateManifest } from '@/helpers/manifestHelper
 import { ManifestDataMap, ManifestSystemVersionPair, SystemSelection } from '@/types/manifestTypes'
 import { customTableStyles } from '../tables/themes'
 import { namesByUri } from '@/pages/programs/[id]/manifest'
+import ManifestDescription from '../ManifestDescription'
 
 interface ModalInfo {
   isOpen: boolean
@@ -291,9 +292,7 @@ const ReleaseModal = ({
         <Typography>
           Manifest versions may be added to specify specific code system versions in this program.
         </Typography>
-        <Typography style={{ display: 'inline-block' }}>
-          Any code systems not specified in the manifest will default to the <b>latest available version.</b>
-        </Typography>
+        <ManifestDescription context='release-modal'/>
         <ManifestDetailTable
           programId={program?.id}
           className="detail-table"

--- a/vsm-app/pages/programs/[id]/manifest.tsx
+++ b/vsm-app/pages/programs/[id]/manifest.tsx
@@ -19,6 +19,7 @@ import Tooltip from '@mui/material/Tooltip'
 import { ErrorMessage } from '@/components/ErrorMessage'
 import { searchAvailableUpdates, updateManifest } from '@/helpers/manifestHelpers'
 import Typography from '@mui/material/Typography'
+import ManifestDescription from '@/components/ManifestDescription'
 
 const endWrapPx = 900
 
@@ -222,13 +223,8 @@ const EditManifestDetails = () => {
       <Row style={{ marginBottom: '1.5rem' }}>
         <Button id="back-to-program" text="&#8592; Back to program" onClick={() => router.push(`/programs/${programId}`)} />
       </Row>
-      <Typography>
-        Manifest versions may be added to specify specific code system versions in this program.
-      </Typography>
-      <Typography style={{ display: 'inline-block' }}>
-        Any code systems not specified in the manifest will default to the <b>latest available version.</b>
-      </Typography>
-      <CodesystemSelectContainer>
+      <ManifestDescription context='manifest-page'/>
+      <CodesystemSelectContainer style={{ marginTop: '3rem' }}>
         <StyledLabel style={{ fontSize: '1rem' }}>Available Version for CodeSystem: </StyledLabel>
         <Select
           isLoading={pageLoading}


### PR DESCRIPTION
Added Accordion component to explain manifest questions
![manifest-release-modal](https://github.com/DBCG/aphl-vsm/assets/8888632/4a0f7bc6-3208-4676-ae4b-b4e598ff44a7)
![manifest-page](https://github.com/DBCG/aphl-vsm/assets/8888632/99ef01a6-ce18-4a9e-88fe-8623b570ac4d)
