### PR TITLE
leaf version should only get passed to groupers if they are pinned

### DIFF
--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -667,7 +667,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
                     return
                   }
                   const groupInfo = e as GroupInfoItem[]
-                  setUpdateVsGroups({ leafCanonical: row?.canonical, leafVersion: row?.version, groupInfo })
+                  setUpdateVsGroups({ leafCanonical: row?.canonical, leafVersion: row?.valueSetPinnedVersion, groupInfo })
                 }}
               />
             </SelectInputContainer>


### PR DESCRIPTION
Luckily a 1-liner... when groupers are updated, they should only set the version if it is pinned.
Following the bullets below, you should no longer see the same condition duplicated

You could see the bug before when you:

- Add a new valueset from our interface (do not pin a version, but add a grouper + condition)
- Go back to program valueset details
- add a condition
- add a group

At this point, there was a duplicate condition, and the version will mysteriously be set when it was ‘latest’ before. This mismatch at the top-level program library (with two conditions appearing, one pointing to the versioned url for that valueset and one pointing to unversioned) is causing the issue with unexpected conditions behavior