### PR TITLE
Fix bug which caused grouper use context not to be added during import

### DIFF
--- a/ecr/src/main/java/com/ecr/ImportBundleProducer.java
+++ b/ecr/src/main/java/com/ecr/ImportBundleProducer.java
@@ -37,6 +37,18 @@ public class ImportBundleProducer {
 				.anyMatch(uc -> uc.hasCode() && uc.getCode().getCode().equals(TransformProperties.grouperType));
 	}
 
+	/**
+	 * Old logic to determine whether a given ValueSet is a grouper.
+	 * We need to use this version for $ersd-v2-import as we need to ensure that the appropriate use context is added,
+	 * if we check for its presence, and it's missing it will not be considered a grouper and therefore is not added.
+	 * @param valueSet
+	 * @return
+	 */
+	public static boolean hasGrouperCompose(ValueSet valueSet) {
+		return valueSet.hasCompose()
+				&& valueSet.getCompose().getIncludeFirstRep().getValueSet().size() > 0;
+	}
+
 	public static boolean isRootSpecificationLibrary(Resource resource) {
 		return resource.hasMeta() && resource.getMeta().hasProfile(TransformProperties.usPHSpecLibProfile);
 	}
@@ -90,7 +102,7 @@ public class ImportBundleProducer {
 					case ValueSet:
 						var valueSet = (ValueSet) resource;
 						var valueSetCanonicalUrl = valueSet.getVersion() == null ? valueSet.getUrl() : valueSet.getUrl() + "|" + valueSet.getVersion();
-						if (isGrouper(valueSet)) {
+						if (hasGrouperCompose(valueSet)) {
 							addModelGrouperUseContextIfMissing(valueSet);
 							var grouperProfiles = addMetaProfileUrl(valueSet.getMeta(), Collections.singletonList(TransformProperties.valueSetGrouperProfile));
 							valueSet.getMeta().setProfile(grouperProfiles);

--- a/ecr/src/test/java/com/ecr/TransformProviderIT.java
+++ b/ecr/src/test/java/com/ecr/TransformProviderIT.java
@@ -272,4 +272,51 @@ class TransformProviderIT extends RestIntegrationTest {
 		}
 		assertTrue(atLeastOneRelatedArtifactIsAValueSetWithPriority);
 	}
+
+	@Test
+	void testImportOperation_appliesGrouperUseContext() throws InterruptedException {
+		Bundle v2Bundle = (Bundle) loadResource("ersd-bundle-example-missing-grouper-use-context.json");
+		Parameters v2BundleParams = new Parameters();
+		v2BundleParams.addParameter()
+				.setName("bundle")
+				.setResource(v2Bundle);
+
+		getClient()
+				.operation()
+				.onServer()
+				.named("$ersd-v2-import")
+				.withParameters(v2BundleParams)
+				.returnResourceType(OperationOutcome.class)
+				.execute();
+
+		Thread.sleep(1000);
+
+		int bundleSearchTries = 0;
+
+		Bundle results = getClient().search()
+				.forResource(ValueSet.class)
+				.returnBundle(Bundle.class)
+				.execute();
+
+		while (results.getEntry().isEmpty() && bundleSearchTries < 3) {
+			Thread.sleep(1500);
+			bundleSearchTries++;
+			results = getClient().search()
+					.forResource(ValueSet.class)
+					.returnBundle(Bundle.class)
+					.execute();
+		}
+
+		if(results.getEntry().isEmpty()) {
+			fail("Bundle is empty, fetching the import is not returning any entries");
+		}
+
+		List<ValueSet> importedGroupers = results.getEntry().stream()
+				.filter(entry -> entry.getResource() instanceof MetadataResource && ImportBundleProducer.isGrouper((MetadataResource) entry.getResource()))
+				.map(entry -> (ValueSet)entry.getResource())
+				.collect(Collectors.toList());
+
+		// After the import, check all of them have the group type as use context
+		assertEquals(6,importedGroupers.size());
+	}
 }

--- a/ecr/src/test/resources/ersd-bundle-example-missing-grouper-use-context.json
+++ b/ecr/src/test/resources/ersd-bundle-example-missing-grouper-use-context.json
@@ -1,0 +1,9753 @@
+{
+	"resourceType": "Bundle",
+	"id": "bundle-ersd-specification-example",
+	"meta": {
+		"versionId": "1",
+		"lastUpdated": "2022-04-15T18:26:27.000+00:00",
+		"source": "#8zRKOv2AelmrnTVL"
+	},
+	"type": "collection",
+	"timestamp": "2022-04-05T10:06:42.482-04:00",
+	"entry": [
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary",
+			"resource": {
+				"resourceType": "Library",
+				"id": "SpecificationLibrary",
+				"meta": {
+					"versionId": "1.0.0",
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-specification-library"
+					]
+				},
+				"text": {
+					"status": "generated",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Library</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Library \"SpecificationLibrary\" Version \"1.0.0\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-specification-library.html\">US Public Health Specification Library</a></p></div><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary</code></p><p><b>version</b>: 1.0.0</p><p><b>name</b>: SpecificationLibrary</p><p><b>title</b>: Specification Library</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>type</b>: Asset Collection <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-library-type.html\">LibraryType</a>#asset-collection)</span></p><p><b>publisher</b>: eCR</p><p><b>description</b>: Defines the asset-collection library containing the US Public Health specification assets.</p></div>"
+				},
+				"url": "http://hl7.org/fhir/us/ecr/Library/SpecificationLibrary",
+				"version": "1.0.0",
+				"name": "SpecificationLibrary",
+				"title": "Specification Library",
+				"status": "active",
+				"experimental": true,
+				"type": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/library-type",
+							"code": "asset-collection"
+						}
+					]
+				},
+				"publisher": "eCR",
+				"description": "Defines the asset-collection library containing the US Public Health specification assets.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "specification-type"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "program"
+								}
+							]
+						}
+					}
+				],
+				"relatedArtifact": [
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/Library/library-rctc-example",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example",
+			"resource": {
+				"resourceType": "PlanDefinition",
+				"id": "plandefinition-ersd-instance-example",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-plandefinition"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: PlanDefinition</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource PlanDefinition \"plandefinition-ersd-instance-example\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-ersd-plandefinition.html\">eRSD PlanDefinition</a></p></div><p><b>Variable</b>: <span title=\"text/fhirpath\"><code>14</code></span>(<b>normalReportingDuration</b>)</p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example</code></p><p><b>version</b>: 0.1</p><p><b>name</b>: PlanDefinition_eRSD_Instance_Example</p><p><b>title</b>: eRSD PlanDefinition Instance Example</p><p><b>type</b>: Workflow Definition <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-plan-definition-type.html\">PlanDefinitionType</a>#workflow-definition)</span></p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>date</b>: 2020-07-31 12:32:29-0500</p><p><b>publisher</b>: HL7 Public Health Work Group</p><p><b>description</b>: An example ersd PlanDefinition</p><p><b>jurisdiction</b>: United States of America <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#US)</span></p><p><b>effectivePeriod</b>: 2020-12-01 --&gt; (ongoing)</p><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the start of the reporting workflow in response to the encounter-start event.</p><p><b>textEquivalent</b>: Start the reporting workflow in response to an encounter-start event</p><p><b>code</b>: Initiate a reporting workflow <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#initiate-reporting-workflow)</span></p><h3>RelatedActions</h3><table class=\"grid\"><tr><td>-</td><td><b>ActionId</b></td><td><b>Relationship</b></td><td><b>Offset[x]</b></td></tr><tr><td>*</td><td>check-suspected-disorder</td><td>before-start</td><td>1 h<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code h = 'h')</span></td></tr></table></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the start of the check suspected disorder reporting workflow in response to the encounter-start event.</p><p><b>textEquivalent</b>: Check suspected disorders for immediate reportability and setup jobs for future reportability checks.</p><p><b>code</b>: Execute a series of actions to accomplish reporting <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#execute-reporting-workflow)</span></p><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the check for suspected disorder reportability to create the patients eICR.</p><p><b>textEquivalent</b>: Check Trigger Codes based on Suspected Reportable Value set.</p><p><b>code</b>: Evaluate candidate patient's data against trigger codes to determine reportability <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#check-trigger-codes)</span></p></blockquote><blockquote><p><b>action</b></p><p><b>code</b>: Evaluate condition to determine reportability <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#evaluate-condition)</span></p></blockquote></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the check for suspected reportability of the eICR.</p><p><b>textEquivalent</b>: Check Reportability and setup jobs for future reportability checks.</p><p><b>code</b>: Execute a series of actions to accomplish reporting <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#execute-reporting-workflow)</span></p><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the check for reportability to create the patients eICR.</p><p><b>textEquivalent</b>: Check Trigger Codes based on RCTC Value sets.</p><p><b>code</b>: Evaluate candidate patient's data against trigger codes to determine reportability <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#check-trigger-codes)</span></p></blockquote><blockquote><p><b>action</b></p><p><b>code</b>: Evaluate condition to determine reportability <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#evaluate-condition)</span></p></blockquote><blockquote><p><b>action</b></p><p><b>code</b>: Evaluate condition to determine reportability <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#evaluate-condition)</span></p></blockquote><blockquote><p><b>action</b></p><p><b>code</b>: Complete reporting for the patient <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#complete-reporting)</span></p></blockquote></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the creation of the eICR. It subsequently calls validate.</p><p><b>textEquivalent</b>: Create eICR</p><p><b>code</b>: Create a Report containing Patient's data for patients who passed the check-reportability test <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#create-report)</span></p><h3>RelatedActions</h3><table class=\"grid\"><tr><td>-</td><td><b>ActionId</b></td><td><b>Relationship</b></td></tr><tr><td>*</td><td>validate-eicr</td><td>before-start</td></tr></table></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the validation of the eICR. It subsequently calls route-and-send.</p><p><b>textEquivalent</b>: Validate eICR</p><p><b>code</b>: Validate Report against specified profiles and terminologies. <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#validate-report)</span></p><h3>RelatedActions</h3><table class=\"grid\"><tr><td>-</td><td><b>ActionId</b></td><td><b>Relationship</b></td></tr><tr><td>*</td><td>route-and-send-eicr</td><td>before-start</td></tr></table></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the routing and sending of the eICR.</p><p><b>textEquivalent</b>: Route and send eICR</p><p><b>code</b>: Submit the report to specified endpoint <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#submit-report)</span></p></blockquote><blockquote><p><b>action</b></p><p><b>description</b>: This action represents the start of the reporting workflow in response to the encounter-modified event</p><p><b>textEquivalent</b>: Start the reporting workflow in response to an encounter-modified event</p><p><b>code</b>: Initiate a reporting workflow <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-us-ph-plandefinition-actions.html\">US Public Health PlanDefinition Action Codes</a>#initiate-reporting-workflow)</span></p><blockquote><p><b>condition</b></p><p><b>kind</b>: applicability</p></blockquote><h3>RelatedActions</h3><table class=\"grid\"><tr><td>-</td><td><b>ActionId</b></td><td><b>Relationship</b></td></tr><tr><td>*</td><td>create-eicr</td><td>before-start</td></tr></table></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/variable",
+						"valueExpression": {
+							"name": "normalReportingDuration",
+							"language": "text/fhirpath",
+							"expression": "14"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example",
+				"version": "0.1",
+				"name": "PlanDefinition_eRSD_Instance_Example",
+				"title": "eRSD PlanDefinition Instance Example",
+				"type": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+							"code": "workflow-definition",
+							"display": "Workflow Definition"
+						}
+					]
+				},
+				"status": "active",
+				"experimental": true,
+				"date": "2020-07-31T12:32:29.858-05:00",
+				"publisher": "HL7 Public Health Work Group",
+				"description": "An example ersd PlanDefinition",
+				"jurisdiction": [
+					{
+						"coding": [
+							{
+								"system": "urn:iso:std:iso:3166",
+								"code": "US",
+								"display": "United States of America"
+							}
+						],
+						"text": "United States of America"
+					}
+				],
+				"effectivePeriod": {
+					"start": "2020-12-01"
+				},
+				"relatedArtifact": [
+					{
+						"type": "depends-on",
+						"label": "RCTC Value Set Library of Trigger Codes",
+						"resource": "http://hl7.org/fhir/us/ecr/Library/library-rctc-example|2022-01-01"
+					}
+				],
+				"action": [
+					{
+						"id": "start-workflow",
+						"description": "This action represents the start of the reporting workflow in response to the encounter-start event.",
+						"textEquivalent": "Start the reporting workflow in response to an encounter-start event",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "initiate-reporting-workflow",
+										"display": "Initiate a reporting workflow"
+									}
+								]
+							}
+						],
+						"trigger": [
+							{
+								"id": "encounter-start",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-named-eventtype-extension",
+										"valueCodeableConcept": {
+											"coding": [
+												{
+													"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-triggerdefinition-namedevents",
+													"code": "encounter-start",
+													"display": "Indicates the start of an encounter"
+												}
+											]
+										}
+									}
+								],
+								"type": "named-event",
+								"name": "encounter-start"
+							}
+						],
+						"input": [
+							{
+								"id": "patient",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+										"valueString": "Patient/{{context.patientId}}"
+									}
+								],
+								"type": "Patient"
+							},
+							{
+								"id": "encounter",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+										"valueString": "Encounter/{{context.encounterId}}"
+									}
+								],
+								"type": "Encounter"
+							}
+						],
+						"relatedAction": [
+							{
+								"actionId": "check-suspected-disorder",
+								"relationship": "before-start",
+								"offsetDuration": {
+									"value": 1,
+									"system": "http://unitsofmeasure.org",
+									"code": "h"
+								}
+							}
+						]
+					},
+					{
+						"id": "check-suspected-disorder",
+						"description": "This action represents the start of the check suspected disorder reporting workflow in response to the encounter-start event.",
+						"textEquivalent": "Check suspected disorders for immediate reportability and setup jobs for future reportability checks.",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "execute-reporting-workflow"
+									}
+								]
+							}
+						],
+						"action": [
+							{
+								"id": "is-encounter-suspected-disorder",
+								"description": "This action represents the check for suspected disorder reportability to create the patients eICR.",
+								"textEquivalent": "Check Trigger Codes based on Suspected Reportable Value set.",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "check-trigger-codes"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Is Suspected Disorder?",
+														"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "%modifiedConditions.exists() or %modifiedLabResults.exists() or %modifiedMedicationOrders.exists()"
+										}
+									}
+								],
+								"input": [
+									{
+										"id": "modifiedConditions",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Condition?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Condition",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc"
+											}
+										]
+									},
+									{
+										"id": "modifiedLabResults",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Observation?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Observation",
+										"codeFilter": [
+											{
+												"path": "value",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/lotc"
+											}
+										]
+									},
+									{
+										"id": "modifiedMedicationOrders",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "MedicationRequest?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "MedicationRequest",
+										"codeFilter": [
+											{
+												"path": "medication",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc"
+											}
+										]
+									}
+								],
+								"relatedAction": [
+									{
+										"actionId": "create-eicr",
+										"relationship": "before-start"
+									}
+								]
+							},
+							{
+								"id": "continue-check-reportable",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "evaluate-condition"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Is Encounter In Progress and Within Normal Reporting Duration or 72h or less after end of encounter?",
+														"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "%encounter.where((status = 'in-progress' and period.start + 1 day * %normalReportingDuration >= now()) or (status = 'finished' and period.end + 72 hours >= now())).select(true)"
+										}
+									}
+								],
+								"relatedAction": [
+									{
+										"actionId": "check-reportable",
+										"relationship": "before-start",
+										"offsetDuration": {
+											"value": 6,
+											"comparator": "<=",
+											"system": "http://unitsofmeasure.org",
+											"code": "h"
+										}
+									}
+								]
+							}
+						]
+					},
+					{
+						"id": "check-reportable",
+						"description": "This action represents the check for suspected reportability of the eICR.",
+						"textEquivalent": "Check Reportability and setup jobs for future reportability checks.",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "execute-reporting-workflow"
+									}
+								]
+							}
+						],
+						"action": [
+							{
+								"id": "is-encounter-reportable",
+								"description": "This action represents the check for reportability to create the patients eICR.",
+								"textEquivalent": "Check Trigger Codes based on RCTC Value sets.",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "check-trigger-codes"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Is Encounter Reportable and Within Normal Reporting Duration?",
+														"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "%encounter.where(period.start + 1 day * %normalReportingDuration >= now()).select(true) and (%conditions.exists() or %encounters.exists() or %immunizations.exists() or %procedures.exists() or %procedureOrders.exists() or %labOrders.exists() or %labTests.exists() or %labResults.exists() or %medicationAdministrations.exists() or %medicationOrders.exists() or %medicationDispenses.exists())"
+										}
+									}
+								],
+								"input": [
+									{
+										"id": "conditions",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Condition?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Condition",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc"
+											}
+										]
+									},
+									{
+										"id": "encounters",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "encounter"
+											}
+										],
+										"type": "Encounter",
+										"codeFilter": [
+											{
+												"path": "reasonCode",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc"
+											}
+										]
+									},
+									{
+										"id": "immunizations",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Immunization?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Immunization",
+										"codeFilter": [
+											{
+												"path": "vaccineCode",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc"
+											}
+										]
+									},
+									{
+										"id": "labOrders",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "ServiceRequest?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "ServiceRequest",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/lotc"
+											}
+										]
+									},
+									{
+										"id": "labTests",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Observation?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Observation",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/lotc"
+											}
+										]
+									},
+									{
+										"id": "diagnosticOrders",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "DiagnosticReport?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "DiagnosticReport",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/lotc"
+											}
+										]
+									},
+									{
+										"id": "procedureOrders",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "ServiceRequest?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "ServiceRequest",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/valueset-pctc-example"
+											}
+										]
+									},
+									{
+										"id": "procedures",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "Procedure?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "Procedure",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/valueset-pctc-example"
+											}
+										]
+									},
+									{
+										"id": "medicationOrders",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "MedicationRequest?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "MedicationRequest",
+										"codeFilter": [
+											{
+												"path": "medication",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc"
+											}
+										]
+									},
+									{
+										"id": "medicationDispenses",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "MedicationDispense?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "MedicationDispense",
+										"codeFilter": [
+											{
+												"path": "medication",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc"
+											}
+										]
+									},
+									{
+										"id": "medicationAdministrations",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-fhirquerypattern-extension",
+												"valueString": "MedicationAdministration?patient=Patient/{{context.patientId}}"
+											}
+										],
+										"type": "MedicationAdministration",
+										"codeFilter": [
+											{
+												"path": "medication",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc"
+											}
+										]
+									},
+									{
+										"id": "labResults",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "labTests"
+											}
+										],
+										"type": "Observation",
+										"codeFilter": [
+											{
+												"path": "value",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/ostc"
+											}
+										]
+									},
+									{
+										"id": "diagnosticResults",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "diagnosticOrders"
+											}
+										],
+										"type": "DiagnosticReport",
+										"codeFilter": [
+											{
+												"path": "code",
+												"valueSet": "http://hl7.org/fhir/us/ecr/ValueSet/ostc"
+											}
+										]
+									}
+								],
+								"relatedAction": [
+									{
+										"actionId": "create-eicr",
+										"relationship": "before-start"
+									}
+								]
+							},
+							{
+								"id": "check-update-eicr",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "evaluate-condition"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Most recent eICR sent over 72 hours ago?",
+														"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "((%lasteicr.last().entry[2].resource as Bundle).entry.first().resource as Composition).date < now() - 72 hours"
+										}
+									}
+								],
+								"input": [
+									{
+										"id": "lasteicr",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "eicrreport"
+											}
+										],
+										"type": "Bundle",
+										"profile": [
+											"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+										]
+									}
+								],
+								"relatedAction": [
+									{
+										"actionId": "create-eicr",
+										"relationship": "before-start"
+									}
+								]
+							},
+							{
+								"id": "is-encounter-in-progress",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "evaluate-condition"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Is Encounter In Progress and Within Normal Reporting Duration or 72h or less after end of encounter?",
+														"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "%inprogressencounter.where(status = 'in-progress' and period.start + 1 day * %normalReportingDuration >= now() or (status = 'finished' and period.end + 72 hours >= now())).exists()"
+										}
+									}
+								],
+								"input": [
+									{
+										"id": "inprogressencounter",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "encounter"
+											}
+										],
+										"type": "Encounter"
+									}
+								],
+								"relatedAction": [
+									{
+										"actionId": "check-reportable",
+										"relationship": "before-start",
+										"offsetDuration": {
+											"value": 6,
+											"comparator": "<=",
+											"system": "http://unitsofmeasure.org",
+											"code": "h"
+										}
+									}
+								]
+							},
+							{
+								"id": "is-encounter-completed",
+								"code": [
+									{
+										"coding": [
+											{
+												"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+												"code": "complete-reporting"
+											}
+										]
+									}
+								],
+								"condition": [
+									{
+										"kind": "applicability",
+										"expression": {
+											"extension": [
+												{
+													"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+													"valueExpression": {
+														"language": "text/cql-identifier",
+														"expression": "Is Encounter Complete",
+														"reference": "http://aphl.org/fhir/ecr/Library/RuleFilters|2.1.0"
+													}
+												}
+											],
+											"language": "text/fhirpath",
+											"expression": "%completedEncounter.exists(status = 'finished')"
+										}
+									}
+								],
+								"input": [
+									{
+										"id": "completedEncounter",
+										"extension": [
+											{
+												"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+												"valueString": "encounter"
+											}
+										],
+										"type": "Encounter"
+									}
+								]
+							}
+						]
+					},
+					{
+						"id": "create-eicr",
+						"description": "This action represents the creation of the eICR. It subsequently calls validate.",
+						"textEquivalent": "Create eICR",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "create-report"
+									}
+								]
+							}
+						],
+						"input": [
+							{
+								"id": "patientdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "patient"
+									}
+								],
+								"type": "Patient",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+								]
+							},
+							{
+								"id": "conditiondata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "conditions"
+									}
+								],
+								"type": "Condition",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+								]
+							},
+							{
+								"id": "encounterdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "encounter"
+									}
+								],
+								"type": "Encounter",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+								]
+							},
+							{
+								"id": "mrdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "medicationOrders"
+									}
+								],
+								"type": "MedicationRequest",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+								]
+							},
+							{
+								"id": "immzdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "immunizations"
+									}
+								],
+								"type": "Immunization",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+								]
+							},
+							{
+								"id": "procdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "procedures"
+									}
+								],
+								"type": "Procedure",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+								]
+							},
+							{
+								"id": "labResultdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "labResults"
+									}
+								],
+								"type": "Observation",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+								]
+							},
+							{
+								"id": "labOrderdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "labOrders"
+									}
+								],
+								"type": "ServiceRequest",
+								"profile": [
+									"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+								]
+							},
+							{
+								"id": "diagnosticResultdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "diagnosticResults"
+									}
+								],
+								"type": "DiagnosticReport",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+								]
+							},
+							{
+								"id": "diagnosticOrderdata",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "diagnosticOrders"
+									}
+								],
+								"type": "DiagnosticReport",
+								"profile": [
+									"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+								]
+							}
+						],
+						"output": [
+							{
+								"id": "eicrreport",
+								"type": "Bundle",
+								"profile": [
+									"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+								]
+							}
+						],
+						"relatedAction": [
+							{
+								"actionId": "validate-eicr",
+								"relationship": "before-start"
+							}
+						]
+					},
+					{
+						"id": "validate-eicr",
+						"description": "This action represents the validation of the eICR. It subsequently calls route-and-send.",
+						"textEquivalent": "Validate eICR",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "validate-report"
+									}
+								]
+							}
+						],
+						"input": [
+							{
+								"id": "generatedeicrreport",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "eicrreport"
+									}
+								],
+								"type": "Bundle",
+								"profile": [
+									"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+								]
+							}
+						],
+						"output": [
+							{
+								"id": "valideicrreport",
+								"type": "Bundle",
+								"profile": [
+									"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+								]
+							}
+						],
+						"relatedAction": [
+							{
+								"actionId": "route-and-send-eicr",
+								"relationship": "before-start"
+							}
+						]
+					},
+					{
+						"id": "route-and-send-eicr",
+						"description": "This action represents the routing and sending of the eICR.",
+						"textEquivalent": "Route and send eICR",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "submit-report"
+									}
+								]
+							}
+						],
+						"input": [
+							{
+								"id": "validatedeicrreport",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-relateddata-extension",
+										"valueString": "valideicrreport"
+									}
+								],
+								"type": "Bundle",
+								"profile": [
+									"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+								]
+							}
+						],
+						"output": [
+							{
+								"id": "submittedeicrreport",
+								"type": "Bundle",
+								"profile": [
+									"http://hl7.org/fhir/us/ecr/StructureDefinition/eicr-document-bundle"
+								]
+							}
+						]
+					},
+					{
+						"id": "encounter-modified",
+						"description": "This action represents the start of the reporting workflow in response to the encounter-modified event",
+						"textEquivalent": "Start the reporting workflow in response to an encounter-modified event",
+						"code": [
+							{
+								"coding": [
+									{
+										"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-plandefinition-actions",
+										"code": "initiate-reporting-workflow",
+										"display": "Initiate a reporting workflow"
+									}
+								]
+							}
+						],
+						"trigger": [
+							{
+								"id": "encounter-modified-trigger",
+								"extension": [
+									{
+										"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-named-eventtype-extension",
+										"valueCodeableConcept": {
+											"coding": [
+												{
+													"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-triggerdefinition-namedevents",
+													"code": "encounter-modified",
+													"display": "Indicates modifications to data elements of an encounter"
+												}
+											]
+										}
+									}
+								],
+								"type": "named-event",
+								"name": "encounter-modified"
+							}
+						],
+						"condition": [
+							{
+								"kind": "applicability",
+								"expression": {
+									"extension": [
+										{
+											"url": "http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-alternative-expression-extension",
+											"valueExpression": {
+												"language": "text/cql-identifier",
+												"expression": "Is Encounter Longer Than Normal Reporting Duration?",
+												"reference": "http://hl7.org/fhir/us/ecr/Library/RuleFilters|2.1.0"
+											}
+										}
+									],
+									"language": "text/fhirpath",
+									"expression": "%encounter.where(period.start + 1 day * %normalReportingDuration < now()).select(true)"
+								}
+							}
+						],
+						"relatedAction": [
+							{
+								"actionId": "create-eicr",
+								"relationship": "before-start"
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/Library/library-rctc-example",
+			"resource": {
+				"resourceType": "Library",
+				"id": "library-rctc-example",
+				"meta": {
+					"versionId": "2",
+					"lastUpdated": "2021-08-20T01:12:21.049-06:00",
+					"source": "#zJ5jHSo1bnD4qTAW",
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset-library"
+					]
+				},
+				"text": {
+					"status": "generated",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Library</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Library \"library-rctc-example\" Version \"2\" Updated \"2021-08-20 01:12:21-0600\" </p><p style=\"margin-bottom: 0px\">Information Source: #zJ5jHSo1bnD4qTAW!</p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset-library.html\">US Public Health Triggering ValueSet Library</a></p></div><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/Library/library-rctc-example</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.114222.4.11.7508</p><p><b>version</b>: 2019-06-17</p><p><b>name</b>: Reportable_Condition_Trigger_Codes</p><p><b>title</b>: Reportable Condition Trigger Codes (RCTC) Example Library</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>type</b>: Asset Collection <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-library-type.html\">LibraryType</a>#asset-collection)</span></p><p><b>publisher</b>: {site.data.fhir.ig.publisher}</p><p><b>description</b>: This release includes code updates for the existing conditions and adds codes for Parkinsonâ€™s disease and 13 enteric conditions. Medication codes have also been added to this version.</p><p><b>jurisdiction</b>: United States of America <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#US)</span></p><p><b>purpose</b>: Triggers for initiating decision support for electronic case reports</p><p><b>effectivePeriod</b>: 2019-11-01 --&gt; (ongoing)</p></div>"
+				},
+				"url": "http://hl7.org/fhir/us/ecr/Library/library-rctc-example",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.114222.4.11.7508"
+					}
+				],
+				"version": "2019-06-17",
+				"name": "Reportable_Condition_Trigger_Codes",
+				"title": "Reportable Condition Trigger Codes (RCTC) Example Library",
+				"status": "active",
+				"experimental": true,
+				"type": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/library-type",
+							"code": "asset-collection"
+						}
+					]
+				},
+				"publisher": "{site.data.fhir.ig.publisher}",
+				"description": "This release includes code updates for the existing conditions and adds codes for Parkinsonâ€™s disease and 13 enteric conditions. Medication codes have also been added to this version.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting",
+							"display": "Reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering",
+									"display": "Triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "specification-type",
+							"display": "Specification Type"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "value-set-library",
+									"display": "ValueSet Library"
+								}
+							]
+						}
+					}
+				],
+				"jurisdiction": [
+					{
+						"coding": [
+							{
+								"system": "urn:iso:std:iso:3166",
+								"code": "US",
+								"display": "United States of America"
+							}
+						],
+						"text": "United States of America"
+					}
+				],
+				"purpose": "Triggers for initiating decision support for electronic case reports",
+				"effectivePeriod": {
+					"start": "2019-11-01"
+				},
+				"relatedArtifact": [
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					},
+					{
+						"type": "composed-of",
+						"resource": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",
+						"extension":[
+							{
+								"url":"http://hl7.org/fhir/StructureDefinition/crmi-isOwned",
+								"valueBoolean": true
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "dxtc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"dxtc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/dxtc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.627</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: Diagnosis_ProblemTriggersforPublicHealthReporting</p><p><b>title</b>: Diagnosis_Problem Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains diagnoses or problems that represent that the patient may have a potentially reportable condition. For example, these may be diagnoses recorded in an EHR problem list and diagnosis codes used for billing for the encounter. Purpose: Data Element Scope - Diagnoses or problems documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Diagnoses or problems documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1506/expansion\">Acanthamoeba Disease [Keratitis] (Disorders) (ICD10CM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1505/expansion\">Acanthamoeba Disease [Keratitis] (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1508/expansion\">Arsenic Exposure and Toxicity (Disorders) (ICD10CM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1507/expansion\">Arsenic Exposure and Toxicity (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.6/expansion\">Diphtheria (Disorders) (SNOMED)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: B60.12</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: B60.13</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 127631000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693201000119102</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693241000119100</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693281000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15698841000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15698881000119100</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 231896005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 711645008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 840444002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 840484006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1A</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1D</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1S</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4A</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4D</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4S</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 212516009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216792005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216794006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216795007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 241770003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 241771004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 360406006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 36730005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403740003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403741004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403743001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403744007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403745008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 418685002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 62210001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 72501006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 767146004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 871783000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 89738003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403742006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086051000119107</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086061000119109</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086071000119103</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1090211000119102</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 129667001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 13596001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15682004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 186347006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 18901009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 194945009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 230596007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 240422004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 26117009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 276197005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 3419005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 397428000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 397430003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 48278001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 50215002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 715659006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 75589004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 7773002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 789005009</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/dxtc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.627"
+					}
+				],
+				"version": "1.0.0",
+				"name": "Diagnosis_ProblemTriggersforPublicHealthReporting",
+				"title": "Diagnosis_Problem Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains diagnoses or problems that represent that the patient may have a potentially reportable condition. For example, these may be diagnoses recorded in an EHR problem list and diagnosis codes used for billing for the encounter. Purpose: Data Element Scope - Diagnoses or problems documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Diagnoses or problems documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1506"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1505"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1508"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1507"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "B60.12"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "B60.13"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "127631000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693201000119102"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693241000119100"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693281000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15698841000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15698881000119100"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "231896005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "711645008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "840444002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "840484006"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1A"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1D"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1S"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4A"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4D"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4S"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "212516009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216792005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216794006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216795007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "241770003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "241771004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "360406006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "36730005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403740003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403741004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403743001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403744007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403745008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "418685002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "62210001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "72501006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "767146004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "871783000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "89738003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403742006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086051000119107"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086061000119109"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086071000119103"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1090211000119102"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "129667001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "13596001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15682004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "186347006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "18901009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "194945009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "230596007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "240422004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "26117009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "276197005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "3419005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "397428000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "397430003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "48278001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "50215002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "715659006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "75589004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "7773002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "789005009"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "lotc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"lotc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/lotc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1056</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: LabOrderTestTriggersforPublicHealthReporting</p><p><b>title</b>: Lab Order Test Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains laboratory test names that may be used for placing a lab order for a test that represents that the patient may have a potentially reportable condition. These pertain to laboratory orders placed, coded in LOINC, where the lab order includes at least one test for a condition reportable upon suspicion of the condition. Purpose: Data Element Scope - Laboratory test names used in orders documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Laboratory test names used in orders documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.480/expansion\">Anthrax (Tests for Bacillis anthracis Antigen)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.481/expansion\">Anthrax (Tests for Bacillis anthracis Antibody)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.761/expansion\">Mumps (Test Panels for mumps virus Nucleic Acid)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1223/expansion\">COVID_19 (Tests for SARS_CoV_2 by Culture and Identification Method)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.762/expansion\">Mumps (Test Panels for mumps virus IgM IgG Antibody)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22866-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22867-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31726-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44269-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44270-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 51976-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22860-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22861-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22862-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22863-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22864-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11467-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11468-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22109-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22859-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22865-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5055-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7814-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 85808-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 93750-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 94763-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 94764-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 77250-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 77398-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 88458-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 92929-9</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/lotc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1056"
+					}
+				],
+				"version": "1.0.0",
+				"name": "LabOrderTestTriggersforPublicHealthReporting",
+				"title": "Lab Order Test Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains laboratory test names that may be used for placing a lab order for a test that represents that the patient may have a potentially reportable condition. These pertain to laboratory orders placed, coded in LOINC, where the lab order includes at least one test for a condition reportable upon suspicion of the condition. Purpose: Data Element Scope - Laboratory test names used in orders documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Laboratory test names used in orders documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.762"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22866-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22867-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31726-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44269-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44270-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "51976-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22860-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22861-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22862-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22863-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22864-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11467-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11468-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22109-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22859-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22865-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5055-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7814-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "85808-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "93750-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "94763-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "94764-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "77250-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "77398-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "88458-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "92929-9"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "lrtc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"lrtc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/lrtc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1057</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: LabObsTestTriggersforPublicHealthReporting</p><p><b>title</b>: Lab Obs Test Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains laboratory observation test names that may represent that the patient may have a potentially reportable condition. These pertain to resulted laboratory reports, where the lab test name, coded in LOINC, is specific to a reportable condition. Purpose: Data Element Scope - Laboratory test names used in observations documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Laboratory test names used in observations documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1182/expansion\">Powassan Virus Disease (Tests for Powassan Virus Antibody [Quantitative])</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1181/expansion\">Eastern Equine Encephalitis Virus Disease (Tests for Eastern Equine Encephalitis Virus Antibody [Quantitative])</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.480/expansion\">Anthrax (Tests for Bacillis anthracis Antigen)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1184/expansion\">California Serogroup Virus Diseases (Tests for California Serogroup Virus Antibody [Quantitative])</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.481/expansion\">Anthrax (Tests for Bacillis anthracis Antibody)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29564-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30177-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31573-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31574-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40504-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40513-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42973-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42974-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42975-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95647-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30179-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31575-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31576-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42971-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42972-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10896-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10897-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13228-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13918-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 20795-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22257-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22258-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22259-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 23042-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24213-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24214-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24287-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24288-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 34723-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 38764-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43329-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5134-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7860-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95654-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10898-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10899-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13229-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22260-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22261-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 38763-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43330-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7861-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22866-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22867-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31726-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44269-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44270-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 51976-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10904-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17036-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17037-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17038-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22373-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24209-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24210-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24283-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24284-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29561-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29562-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29563-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29782-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29788-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29795-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29801-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29808-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29814-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29821-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29827-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29834-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29839-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29846-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29851-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30174-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31446-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31448-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31450-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31688-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31689-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31690-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35694-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35696-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35697-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35709-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40506-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40507-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40510-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40511-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42952-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43004-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43005-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43006-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43132-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43931-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44746-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44748-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 48716-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49138-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49140-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49194-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49195-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5073-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7940-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9538-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9539-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95637-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95638-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95642-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95653-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10905-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17039-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22375-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29786-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29799-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29812-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29825-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29837-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29849-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31451-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35695-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40508-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40509-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42953-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43003-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44822-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49139-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49141-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49193-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 62946-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7941-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9540-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22860-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22861-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22862-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22863-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22864-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11467-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11468-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22109-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22859-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22865-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5055-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7814-7</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/lrtc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1057"
+					}
+				],
+				"version": "1.0.0",
+				"name": "LabObsTestTriggersforPublicHealthReporting",
+				"title": "Lab Obs Test Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains laboratory observation test names that may represent that the patient may have a potentially reportable condition. These pertain to resulted laboratory reports, where the lab test name, coded in LOINC, is specific to a reportable condition. Purpose: Data Element Scope - Laboratory test names used in observations documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Laboratory test names used in observations documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29564-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30177-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31573-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31574-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40504-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40513-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42973-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42974-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42975-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95647-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30179-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31575-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31576-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42971-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42972-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10896-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10897-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13228-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13918-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "20795-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22257-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22258-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22259-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "23042-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24213-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24214-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24287-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24288-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "34723-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "38764-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43329-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5134-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7860-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95654-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10898-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10899-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13229-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22260-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22261-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "38763-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43330-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7861-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22866-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22867-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31726-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44269-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44270-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "51976-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10904-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17036-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17037-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17038-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22373-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24209-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24210-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24283-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24284-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29561-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29562-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29563-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29782-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29788-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29795-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29801-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29808-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29814-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29821-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29827-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29834-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29839-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29846-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29851-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30174-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31446-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31448-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31450-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31688-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31689-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31690-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35694-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35696-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35697-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35709-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40506-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40507-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40510-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40511-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42952-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43004-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43005-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43006-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43132-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43931-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44746-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44748-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "48716-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49138-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49140-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49194-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49195-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5073-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7940-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9538-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9539-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95637-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95638-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95642-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95653-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10905-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17039-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22375-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29786-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29799-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29812-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29825-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29837-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29849-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31451-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35695-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40508-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40509-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42953-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43003-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44822-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49139-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49141-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49193-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "62946-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7941-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9540-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22860-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22861-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22862-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22863-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22864-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11467-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11468-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22109-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22859-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22865-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5055-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7814-7"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "mrtc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"mrtc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/mrtc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1060</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: MedicationsTriggersforPublicHealthReporting</p><p><b>title</b>: Medications Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains CVX,RXNORM,SNOMED medication codes that may represent that the patient may have a potentially reportable condition. These pertain to medications administered and medications prescribed, where the medication, coded in CVX,RXNORM,SNOMED, may be indicative of a reportable condition. Purpose: Data Element Scope - Prescription drugs names used in observations documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Prescription drugs names used in observations documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1601/expansion\">HIV Infection (ARV Boosters [CYP3A4 Inhibitor]) (RXNORM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1600/expansion\">HIV Infection (ARV Integrase Strand Transfer Inhibitors [INSTIs]) (RXNORM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1603/expansion\">HIV Infection (ARV Attachment Inhibitors) (RXNORM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1602/expansion\">HIV Infection (ARV Postattachment Inhibitors) (RXNORM)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1082/expansion\">Anthrax Vaccine (RXNORM)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1551993</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1551999</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 152970</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 152971</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1926066</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1926069</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 199249</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 317150</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 900575</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 900577</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235588</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235591</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235593</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235595</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1433873</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1433879</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1486838</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1486841</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796077</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796079</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796081</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796083</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1924313</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1924315</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2374562</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2374566</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2475199</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2475205</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 744842</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 744846</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1999667</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1999673</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2380549</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2380551</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2043317</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2043322</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 832679</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 832682</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/mrtc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1060"
+					}
+				],
+				"version": "1.0.0",
+				"name": "MedicationsTriggersforPublicHealthReporting",
+				"title": "Medications Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains CVX,RXNORM,SNOMED medication codes that may represent that the patient may have a potentially reportable condition. These pertain to medications administered and medications prescribed, where the medication, coded in CVX,RXNORM,SNOMED, may be indicative of a reportable condition. Purpose: Data Element Scope - Prescription drugs names used in observations documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Prescription drugs names used in observations documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1551993"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1551999"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "152970"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "152971"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1926066"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1926069"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "199249"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "317150"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "900575"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "900577"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235588"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235591"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235593"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235595"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1433873"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1433879"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1486838"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1486841"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796077"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796079"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796081"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796083"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1924313"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1924315"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2374562"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2374566"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2475199"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2475205"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "744842"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "744846"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1999667"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1999673"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2380549"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2380551"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2043317"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2043322"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "832679"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "832682"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "ostc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"ostc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/ostc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1059</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: Organism_SubstanceReleaseTriggersforPublicHealthReporting</p><p><b>title</b>: Organism_Substance Release Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains organism and substance names received in a laboratory results report, that may represent that the patient has a potentially reportable condition. These pertain to resulted laboratory reports, where the test method is a non-specific test (e.g., general cultures not specific to a condition) and the result value, coded in SNOMED, includes the organism or substance name. Purpose: Data Element Scope - Nominal laboratory result values documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Nominal laboratory result values documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.528/expansion\">Dengue Virus Infection (Organism or Substance in Lab Results)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.408/expansion\">Hepatitis B Virus Infection (Organism or Substance in Lab Results)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.409/expansion\">Hepatitis C Virus Infection (Organism or Substance in Lab Results)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1469/expansion\">Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1468/expansion\">Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121020003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121182007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121192004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 243604005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 34348001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 36700002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 41328007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 60588009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707875002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707876001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707877005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707878000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 783725005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 8467002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121112003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121184008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 13105002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 22290004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 303233001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 39082004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 52680001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 60605004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 63350005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703886001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703887005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703888000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703889008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703890004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703891000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703892007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703893002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708281003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 716076002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 73661005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 81665004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121022006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121185009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121204002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 371140008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603413005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603414004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603415003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603416002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603417006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603418001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603419009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603420003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603421004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603422006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603423001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603424007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603425008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603426009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603427000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603428005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603429002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603430007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603431006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603432004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603433009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 62944002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 711331006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 726592002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 781245007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 781276001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 416397000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708244002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708245001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712664000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712666003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 78065002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 782956001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 782958000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 90272000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 928051771000087103</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707768008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707769000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712663006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712665004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 30949009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 53233007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703032005</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/ostc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1059"
+					}
+				],
+				"version": "1.0.0",
+				"name": "Organism_SubstanceReleaseTriggersforPublicHealthReporting",
+				"title": "Organism_Substance Release Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains organism and substance names received in a laboratory results report, that may represent that the patient has a potentially reportable condition. These pertain to resulted laboratory reports, where the test method is a non-specific test (e.g., general cultures not specific to a condition) and the result value, coded in SNOMED, includes the organism or substance name. Purpose: Data Element Scope - Nominal laboratory result values documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Nominal laboratory result values documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1468"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121020003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121182007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121192004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "243604005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "34348001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "36700002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "41328007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "60588009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707875002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707876001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707877005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707878000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "783725005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "8467002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121112003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121184008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "13105002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "22290004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "303233001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "39082004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "52680001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "60605004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "63350005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703886001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703887005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703888000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703889008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703890004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703891000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703892007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703893002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708281003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "716076002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "73661005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "81665004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121022006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121185009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121204002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "371140008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603413005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603414004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603415003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603416002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603417006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603418001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603419009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603420003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603421004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603422006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603423001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603424007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603425008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603426009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603427000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603428005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603429002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603430007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603431006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603432004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603433009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "62944002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "711331006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "726592002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "781245007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "781276001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "416397000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708244002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708245001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712664000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712666003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "78065002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "782956001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "782958000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "90272000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "928051771000087103"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707768008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707769000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712663006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712665004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "30949009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "53233007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703032005"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "sdtc",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"sdtc\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://hl7.org/fhir/us/ecr/ValueSet/sdtc</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1479</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: Suspected_DisorderTriggersforPublicHealthReporting</p><p><b>title</b>: Suspected_Disorder Triggers for Public Health Reporting</p><p><b>status</b>: draft</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Purpose: Clinical Focus - This set of values contains suspected diagnoses or problems that represent that the patient may have a potentially reportable condition. For example, these may be diagnoses recorded in an EHR problem list and diagnosis codes used for billing for the encounter. Purpose: Data Element Scope - Suspected diagnoses or problems documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.</p><p><b>purpose</b>: Suspected diagnoses or problems documented in a clinical record.</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1439/expansion\">Rabies [Suspected] (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1436/expansion\">Measles [Suspected] (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1435/expansion\">Diphtheria [Suspected] (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1446/expansion\">Viral Hemorrhagic Fever [Suspected] (Disorders) (SNOMED)</a></p></blockquote><blockquote><p><b>include</b></p><p><b>valueSet</b>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1438/expansion\">Poliomyelitis [Suspected] (Disorders) (SNOMED)</a></p></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 722545003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 722546002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 772152006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 772150003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 772158005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 772155008</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://hl7.org/fhir/us/ecr/ValueSet/sdtc",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1479"
+					}
+				],
+				"version": "1.0.0",
+				"name": "Suspected_DisorderTriggersforPublicHealthReporting",
+				"title": "Suspected_Disorder Triggers for Public Health Reporting",
+				"status": "draft",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Purpose: Clinical Focus - This set of values contains suspected diagnoses or problems that represent that the patient may have a potentially reportable condition. For example, these may be diagnoses recorded in an EHR problem list and diagnosis codes used for billing for the encounter. Purpose: Data Element Scope - Suspected diagnoses or problems documented in a clinical record. Purpose: Inclusion Criteria - See individual value sets. Purpose: Exclusion Criteria - See individual value sets. Note - Includes codes from selected value sets used in the Reportable Condition Knowledge Management System (RCKMS) reporting logic. RCKMS value sets in VSAC are for informational use only. When implementing trigger codes for electronic case reporting, use the Reportable Condition Trigger Codes (RCTC) file.",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "program"
+						},
+						"valueReference": {
+							"reference": "http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"purpose": "Suspected diagnoses or problems documented in a clinical record.",
+				"compose": {
+					"include": [
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446"
+							]
+						},
+						{
+							"valueSet": [
+								"http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438"
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "722545003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "722546002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772152006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772150003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772158005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772155008"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1506",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1506",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1506\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1506</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1506</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: AcanthamoebaDiseaseKeratitisDisordersICD10CM</p><p><b>title</b>: Acanthamoeba Disease [Keratitis] (Disorders) (ICD10CM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Acanthamoeba Disease [Keratitis] (Disorders) (ICD10CM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><blockquote><p><b>concept</b></p><p><b>code</b>: B60.12</p><p><b>display</b>: Conjunctivitis due to Acanthamoeba</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: B60.13</p><p><b>display</b>: Keratoconjunctivitis due to Acanthamoeba</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: B60.12</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: B60.13</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1506",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1506"
+					}
+				],
+				"version": "1.0.0",
+				"name": "AcanthamoebaDiseaseKeratitisDisordersICD10CM",
+				"title": "Acanthamoeba Disease [Keratitis] (Disorders) (ICD10CM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Acanthamoeba Disease [Keratitis] (Disorders) (ICD10CM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "49649001"
+								}
+							],
+							"text": "Infection caused by Acanthamoeba (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"concept": [
+								{
+									"code": "B60.12",
+									"display": "Conjunctivitis due to Acanthamoeba"
+								},
+								{
+									"code": "B60.13",
+									"display": "Keratoconjunctivitis due to Acanthamoeba"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "B60.12"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "B60.13"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1505",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1505",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1505\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1505</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1505</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: AcanthamoebaDiseaseKeratitisDisordersSNOMED</p><p><b>title</b>: Acanthamoeba Disease [Keratitis] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Acanthamoeba Disease [Keratitis] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 127631000119105</p><p><b>display</b>: Corneal ulcer due to acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15693201000119102</p><p><b>display</b>: Keratitis of bilateral eyes caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15693241000119100</p><p><b>display</b>: Keratitis of left eye caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15693281000119105</p><p><b>display</b>: Keratitis of right eye caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15698841000119105</p><p><b>display</b>: Ulcer of right cornea caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15698881000119100</p><p><b>display</b>: Ulcer of left cornea caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 231896005</p><p><b>display</b>: Acanthamoeba keratitis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 711645008</p><p><b>display</b>: Corneal ulcer caused by Acanthamoeba (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 840444002</p><p><b>display</b>: Dacryoadenitis due to Acanthamoeba keratitis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 840484006</p><p><b>display</b>: Conjunctivitis caused by Acanthamoeba (disorder)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 127631000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693201000119102</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693241000119100</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15693281000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15698841000119105</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15698881000119100</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 231896005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 711645008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 840444002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 840484006</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1505",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1505"
+					}
+				],
+				"version": "1.0.0",
+				"name": "AcanthamoebaDiseaseKeratitisDisordersSNOMED",
+				"title": "Acanthamoeba Disease [Keratitis] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Acanthamoeba Disease [Keratitis] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "49649001"
+								}
+							],
+							"text": "Infection caused by Acanthamoeba (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "127631000119105",
+									"display": "Corneal ulcer due to acanthamoeba (disorder)"
+								},
+								{
+									"code": "15693201000119102",
+									"display": "Keratitis of bilateral eyes caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "15693241000119100",
+									"display": "Keratitis of left eye caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "15693281000119105",
+									"display": "Keratitis of right eye caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "15698841000119105",
+									"display": "Ulcer of right cornea caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "15698881000119100",
+									"display": "Ulcer of left cornea caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "231896005",
+									"display": "Acanthamoeba keratitis (disorder)"
+								},
+								{
+									"code": "711645008",
+									"display": "Corneal ulcer caused by Acanthamoeba (disorder)"
+								},
+								{
+									"code": "840444002",
+									"display": "Dacryoadenitis due to Acanthamoeba keratitis (disorder)"
+								},
+								{
+									"code": "840484006",
+									"display": "Conjunctivitis caused by Acanthamoeba (disorder)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "127631000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693201000119102"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693241000119100"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15693281000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15698841000119105"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15698881000119100"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "231896005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "711645008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "840444002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "840484006"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1508",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1508",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1508\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1508</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1508</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: ArsenicExposureandToxicityDisordersICD10CM</p><p><b>title</b>: Arsenic Exposure and Toxicity (Disorders) (ICD10CM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Arsenic Exposure and Toxicity (Disorders) (ICD10CM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X</p><p><b>display</b>: Toxic effect of arsenic and its compounds</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X1</p><p><b>display</b>: Toxic effect of arsenic and its compounds, accidental (unintentional)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X1A</p><p><b>display</b>: Toxic effect of arsenic and its compounds, accidental (unintentional), initial encounter</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X1D</p><p><b>display</b>: Toxic effect of arsenic and its compounds, accidental (unintentional), subsequent encounter</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X1S</p><p><b>display</b>: Toxic effect of arsenic and its compounds, accidental (unintentional), sequela</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X4</p><p><b>display</b>: Toxic effect of arsenic and its compounds, undetermined</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X4A</p><p><b>display</b>: Toxic effect of arsenic and its compounds, undetermined, initial encounter</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X4D</p><p><b>display</b>: Toxic effect of arsenic and its compounds, undetermined, subsequent encounter</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: T57.0X4S</p><p><b>display</b>: Toxic effect of arsenic and its compounds, undetermined, sequela</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1A</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1D</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X1S</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4A</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4D</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-icd10CM.html\">International Classification of Diseases, 10th Revision, Clinical Modification (ICD-10-CM)</a></p><p><b>version</b>: Provisional_2022-01-12</p><p><b>code</b>: T57.0X4S</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1508",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1508"
+					}
+				],
+				"version": "1.0.0",
+				"name": "ArsenicExposureandToxicityDisordersICD10CM",
+				"title": "Arsenic Exposure and Toxicity (Disorders) (ICD10CM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Arsenic Exposure and Toxicity (Disorders) (ICD10CM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "767146004"
+								}
+							],
+							"text": "Toxic effect of arsenic and its compounds (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"concept": [
+								{
+									"code": "T57.0X",
+									"display": "Toxic effect of arsenic and its compounds"
+								},
+								{
+									"code": "T57.0X1",
+									"display": "Toxic effect of arsenic and its compounds, accidental (unintentional)"
+								},
+								{
+									"code": "T57.0X1A",
+									"display": "Toxic effect of arsenic and its compounds, accidental (unintentional), initial encounter"
+								},
+								{
+									"code": "T57.0X1D",
+									"display": "Toxic effect of arsenic and its compounds, accidental (unintentional), subsequent encounter"
+								},
+								{
+									"code": "T57.0X1S",
+									"display": "Toxic effect of arsenic and its compounds, accidental (unintentional), sequela"
+								},
+								{
+									"code": "T57.0X4",
+									"display": "Toxic effect of arsenic and its compounds, undetermined"
+								},
+								{
+									"code": "T57.0X4A",
+									"display": "Toxic effect of arsenic and its compounds, undetermined, initial encounter"
+								},
+								{
+									"code": "T57.0X4D",
+									"display": "Toxic effect of arsenic and its compounds, undetermined, subsequent encounter"
+								},
+								{
+									"code": "T57.0X4S",
+									"display": "Toxic effect of arsenic and its compounds, undetermined, sequela"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1A"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1D"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X1S"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4A"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4D"
+						},
+						{
+							"system": "http://hl7.org/fhir/sid/icd-10-cm",
+							"version": "Provisional_2022-01-12",
+							"code": "T57.0X4S"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1507",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1507",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1507\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1507</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1507</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: ArsenicExposureandToxicityDisordersSNOMED</p><p><b>title</b>: Arsenic Exposure and Toxicity (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Arsenic Exposure and Toxicity (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 212516009</p><p><b>display</b>: Arsenical anti-infective poisoning (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 216792005</p><p><b>display</b>: Accidental poisoning caused by arsenic and its compounds and fumes (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 216794006</p><p><b>display</b>: Accidental poisoning caused by arsenic compound (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 216795007</p><p><b>display</b>: Accidental poisoning caused by arsenic fumes (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 241770003</p><p><b>display</b>: Trivalent arsenic compound causing toxic effect (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 241771004</p><p><b>display</b>: Pentavalent arsenic compound causing toxic effect (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 360406006</p><p><b>display</b>: Arsenic-induced nail damage (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 36730005</p><p><b>display</b>: Arsenical tremor (finding)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403740003</p><p><b>display</b>: Skin disease caused by arsenic (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403741004</p><p><b>display</b>: Arsenical keratosis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403743001</p><p><b>display</b>: Arsenic-induced skin pigmentation (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403744007</p><p><b>display</b>: Arsenic-induced \"rain-drop\" hypomelanosis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403745008</p><p><b>display</b>: Skin sign from acute arsenic toxicity (finding)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 418685002</p><p><b>display</b>: Poisoning caused by arsenic or its compounds of undetermined intent (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 62210001</p><p><b>display</b>: Inorganic arsenic poisoning (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 72501006</p><p><b>display</b>: Anemia caused by arsenic hydride (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 767146004</p><p><b>display</b>: Toxic effect of arsenic and its compounds (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 871783000</p><p><b>display</b>: Adverse reaction to arsenic and arsenic compound (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 89738003</p><p><b>display</b>: Organic arsenic poisoning (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 403742006</p><p><b>display</b>: Malignant neoplasm of skin caused by arsenic (disorder)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 212516009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216792005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216794006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 216795007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 241770003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 241771004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 360406006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 36730005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403740003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403741004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403743001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403744007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403745008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 418685002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 62210001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 72501006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 767146004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 871783000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 89738003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 403742006</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1507",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1507"
+					}
+				],
+				"version": "1.0.0",
+				"name": "ArsenicExposureandToxicityDisordersSNOMED",
+				"title": "Arsenic Exposure and Toxicity (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Arsenic Exposure and Toxicity (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "767146004"
+								}
+							],
+							"text": "Toxic effect of arsenic and its compounds (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "212516009",
+									"display": "Arsenical anti-infective poisoning (disorder)"
+								},
+								{
+									"code": "216792005",
+									"display": "Accidental poisoning caused by arsenic and its compounds and fumes (disorder)"
+								},
+								{
+									"code": "216794006",
+									"display": "Accidental poisoning caused by arsenic compound (disorder)"
+								},
+								{
+									"code": "216795007",
+									"display": "Accidental poisoning caused by arsenic fumes (disorder)"
+								},
+								{
+									"code": "241770003",
+									"display": "Trivalent arsenic compound causing toxic effect (disorder)"
+								},
+								{
+									"code": "241771004",
+									"display": "Pentavalent arsenic compound causing toxic effect (disorder)"
+								},
+								{
+									"code": "360406006",
+									"display": "Arsenic-induced nail damage (disorder)"
+								},
+								{
+									"code": "36730005",
+									"display": "Arsenical tremor (finding)"
+								},
+								{
+									"code": "403740003",
+									"display": "Skin disease caused by arsenic (disorder)"
+								},
+								{
+									"code": "403741004",
+									"display": "Arsenical keratosis (disorder)"
+								},
+								{
+									"code": "403743001",
+									"display": "Arsenic-induced skin pigmentation (disorder)"
+								},
+								{
+									"code": "403744007",
+									"display": "Arsenic-induced \"rain-drop\" hypomelanosis (disorder)"
+								},
+								{
+									"code": "403745008",
+									"display": "Skin sign from acute arsenic toxicity (finding)"
+								},
+								{
+									"code": "418685002",
+									"display": "Poisoning caused by arsenic or its compounds of undetermined intent (disorder)"
+								},
+								{
+									"code": "62210001",
+									"display": "Inorganic arsenic poisoning (disorder)"
+								},
+								{
+									"code": "72501006",
+									"display": "Anemia caused by arsenic hydride (disorder)"
+								},
+								{
+									"code": "767146004",
+									"display": "Toxic effect of arsenic and its compounds (disorder)"
+								},
+								{
+									"code": "871783000",
+									"display": "Adverse reaction to arsenic and arsenic compound (disorder)"
+								},
+								{
+									"code": "89738003",
+									"display": "Organic arsenic poisoning (disorder)"
+								},
+								{
+									"code": "403742006",
+									"display": "Malignant neoplasm of skin caused by arsenic (disorder)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "212516009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216792005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216794006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "216795007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "241770003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "241771004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "360406006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "36730005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403740003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403741004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403743001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403744007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403745008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "418685002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "62210001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "72501006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "767146004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "871783000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "89738003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "403742006"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.6",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.6\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.6</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: DiphtheriaDisordersSNOMED</p><p><b>title</b>: Diphtheria (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Diphtheria (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 1086051000119107</p><p><b>display</b>: Cardiomyopathy due to diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1086061000119109</p><p><b>display</b>: Diphtheria radiculomyelitis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1086071000119103</p><p><b>display</b>: Diphtheria tubulointerstitial nephropathy (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1090211000119102</p><p><b>display</b>: Pharyngeal diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 129667001</p><p><b>display</b>: Diphtheritic peripheral neuritis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 13596001</p><p><b>display</b>: Diphtheritic peritonitis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 15682004</p><p><b>display</b>: Anterior nasal diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 186347006</p><p><b>display</b>: Diphtheria of penis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 18901009</p><p><b>display</b>: Cutaneous diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 194945009</p><p><b>display</b>: Acute myocarditis - diphtheritic (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 230596007</p><p><b>display</b>: Diphtheritic neuropathy (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 240422004</p><p><b>display</b>: Tracheobronchial diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 26117009</p><p><b>display</b>: Diphtheritic myocarditis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 276197005</p><p><b>display</b>: Infection caused by Corynebacterium diphtheriae (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 3419005</p><p><b>display</b>: Faucial diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 397428000</p><p><b>display</b>: Diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 397430003</p><p><b>display</b>: Diphtheria caused by Corynebacterium diphtheriae (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 48278001</p><p><b>display</b>: Diphtheritic cystitis (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 50215002</p><p><b>display</b>: Laryngeal diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 715659006</p><p><b>display</b>: Diphtheria of respiratory system (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 75589004</p><p><b>display</b>: Nasopharyngeal diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7773002</p><p><b>display</b>: Conjunctival diphtheria (disorder)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 789005009</p><p><b>display</b>: Paralysis of uvula after diphtheria (disorder)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086051000119107</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086061000119109</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1086071000119103</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 1090211000119102</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 129667001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 13596001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 15682004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 186347006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 18901009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 194945009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 230596007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 240422004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 26117009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 276197005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 3419005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 397428000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 397430003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 48278001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 50215002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 715659006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 75589004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 7773002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 789005009</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.6"
+					}
+				],
+				"version": "1.0.0",
+				"name": "DiphtheriaDisordersSNOMED",
+				"title": "Diphtheria (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Diphtheria (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "276197005"
+								}
+							],
+							"text": "Infection caused by Corynebacterium diphtheriae (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "1086051000119107",
+									"display": "Cardiomyopathy due to diphtheria (disorder)"
+								},
+								{
+									"code": "1086061000119109",
+									"display": "Diphtheria radiculomyelitis (disorder)"
+								},
+								{
+									"code": "1086071000119103",
+									"display": "Diphtheria tubulointerstitial nephropathy (disorder)"
+								},
+								{
+									"code": "1090211000119102",
+									"display": "Pharyngeal diphtheria (disorder)"
+								},
+								{
+									"code": "129667001",
+									"display": "Diphtheritic peripheral neuritis (disorder)"
+								},
+								{
+									"code": "13596001",
+									"display": "Diphtheritic peritonitis (disorder)"
+								},
+								{
+									"code": "15682004",
+									"display": "Anterior nasal diphtheria (disorder)"
+								},
+								{
+									"code": "186347006",
+									"display": "Diphtheria of penis (disorder)"
+								},
+								{
+									"code": "18901009",
+									"display": "Cutaneous diphtheria (disorder)"
+								},
+								{
+									"code": "194945009",
+									"display": "Acute myocarditis - diphtheritic (disorder)"
+								},
+								{
+									"code": "230596007",
+									"display": "Diphtheritic neuropathy (disorder)"
+								},
+								{
+									"code": "240422004",
+									"display": "Tracheobronchial diphtheria (disorder)"
+								},
+								{
+									"code": "26117009",
+									"display": "Diphtheritic myocarditis (disorder)"
+								},
+								{
+									"code": "276197005",
+									"display": "Infection caused by Corynebacterium diphtheriae (disorder)"
+								},
+								{
+									"code": "3419005",
+									"display": "Faucial diphtheria (disorder)"
+								},
+								{
+									"code": "397428000",
+									"display": "Diphtheria (disorder)"
+								},
+								{
+									"code": "397430003",
+									"display": "Diphtheria caused by Corynebacterium diphtheriae (disorder)"
+								},
+								{
+									"code": "48278001",
+									"display": "Diphtheritic cystitis (disorder)"
+								},
+								{
+									"code": "50215002",
+									"display": "Laryngeal diphtheria (disorder)"
+								},
+								{
+									"code": "715659006",
+									"display": "Diphtheria of respiratory system (disorder)"
+								},
+								{
+									"code": "75589004",
+									"display": "Nasopharyngeal diphtheria (disorder)"
+								},
+								{
+									"code": "7773002",
+									"display": "Conjunctival diphtheria (disorder)"
+								},
+								{
+									"code": "789005009",
+									"display": "Paralysis of uvula after diphtheria (disorder)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086051000119107"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086061000119109"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1086071000119103"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "1090211000119102"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "129667001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "13596001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "15682004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "186347006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "18901009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "194945009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "230596007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "240422004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "26117009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "276197005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "3419005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "397428000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "397430003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "48278001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "50215002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "715659006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "75589004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "7773002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "789005009"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.480",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.480\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.480</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: AnthraxTestsforBacillisanthracisAntigen</p><p><b>title</b>: Anthrax (Tests for Bacillis anthracis Antigen)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Anthrax (Tests for Bacillis anthracis Antigen)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 22866-8</p><p><b>display</b>: Bacillus anthracis Ag [Presence] in Tissue by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22867-6</p><p><b>display</b>: Bacillus anthracis Ag [Presence] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31726-3</p><p><b>display</b>: Bacillus anthracis Ag [Presence] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 44269-9</p><p><b>display</b>: Bacillus anthracis cell wall Ag [Presence] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 44270-7</p><p><b>display</b>: Bacillus anthracis spore Ag [Presence] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 51976-9</p><p><b>display</b>: Bacillus anthracis capsule Ag [Presence] in Specimen by Immunofluorescence</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22866-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22867-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31726-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44269-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44270-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 51976-9</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.480",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.480"
+					}
+				],
+				"version": "1.0.0",
+				"name": "AnthraxTestsforBacillisanthracisAntigen",
+				"title": "Anthrax (Tests for Bacillis anthracis Antigen)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Anthrax (Tests for Bacillis anthracis Antigen)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "409498004"
+								}
+							],
+							"text": "Anthrax (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "22866-8",
+									"display": "Bacillus anthracis Ag [Presence] in Tissue by Immunofluorescence"
+								},
+								{
+									"code": "22867-6",
+									"display": "Bacillus anthracis Ag [Presence] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "31726-3",
+									"display": "Bacillus anthracis Ag [Presence] in Specimen"
+								},
+								{
+									"code": "44269-9",
+									"display": "Bacillus anthracis cell wall Ag [Presence] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "44270-7",
+									"display": "Bacillus anthracis spore Ag [Presence] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "51976-9",
+									"display": "Bacillus anthracis capsule Ag [Presence] in Specimen by Immunofluorescence"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22866-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22867-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31726-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44269-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44270-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "51976-9"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.481",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.481\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.481</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: AnthraxTestsforBacillisanthracisAntibody</p><p><b>title</b>: Anthrax (Tests for Bacillis anthracis Antibody)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Anthrax (Tests for Bacillis anthracis Antibody)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 22860-1</p><p><b>display</b>: Bacillus anthracis Ab [Presence] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22861-9</p><p><b>display</b>: Bacillus anthracis Ab [Presence] in Serum by Immune diffusion (ID)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22862-7</p><p><b>display</b>: Bacillus anthracis Ab [Presence] in Serum by Agglutination</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22863-5</p><p><b>display</b>: Bacillus anthracis Ab [Presence] in Serum by Immunoassay</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22864-3</p><p><b>display</b>: Bacillus anthracis Ab [Presence] in Serum by Complement fixation</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 11467-8</p><p><b>display</b>: Bacillus anthracis Ab [Units/volume] in Serum by Immunoblot</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 11468-6</p><p><b>display</b>: Bacillus anthracis Ab [Units/volume] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22109-3</p><p><b>display</b>: Bacillus anthracis Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22859-3</p><p><b>display</b>: Bacillus anthracis Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22865-0</p><p><b>display</b>: Bacillus anthracis Ab [Titer] in Serum by Immune diffusion (ID)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 5055-9</p><p><b>display</b>: Bacillus anthracis Ab [Units/volume] in Serum by Hemagglutination</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7814-7</p><p><b>display</b>: Bacillus anthracis Ab [Units/volume] in Serum</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22860-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22861-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22862-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22863-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22864-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11467-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 11468-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22109-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22859-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22865-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5055-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7814-7</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.481",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.481"
+					}
+				],
+				"version": "1.0.0",
+				"name": "AnthraxTestsforBacillisanthracisAntibody",
+				"title": "Anthrax (Tests for Bacillis anthracis Antibody)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Anthrax (Tests for Bacillis anthracis Antibody)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "409498004"
+								}
+							],
+							"text": "Anthrax (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "22860-1",
+									"display": "Bacillus anthracis Ab [Presence] in Serum"
+								},
+								{
+									"code": "22861-9",
+									"display": "Bacillus anthracis Ab [Presence] in Serum by Immune diffusion (ID)"
+								},
+								{
+									"code": "22862-7",
+									"display": "Bacillus anthracis Ab [Presence] in Serum by Agglutination"
+								},
+								{
+									"code": "22863-5",
+									"display": "Bacillus anthracis Ab [Presence] in Serum by Immunoassay"
+								},
+								{
+									"code": "22864-3",
+									"display": "Bacillus anthracis Ab [Presence] in Serum by Complement fixation"
+								},
+								{
+									"code": "11467-8",
+									"display": "Bacillus anthracis Ab [Units/volume] in Serum by Immunoblot"
+								},
+								{
+									"code": "11468-6",
+									"display": "Bacillus anthracis Ab [Units/volume] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "22109-3",
+									"display": "Bacillus anthracis Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "22859-3",
+									"display": "Bacillus anthracis Ab [Titer] in Serum"
+								},
+								{
+									"code": "22865-0",
+									"display": "Bacillus anthracis Ab [Titer] in Serum by Immune diffusion (ID)"
+								},
+								{
+									"code": "5055-9",
+									"display": "Bacillus anthracis Ab [Units/volume] in Serum by Hemagglutination"
+								},
+								{
+									"code": "7814-7",
+									"display": "Bacillus anthracis Ab [Units/volume] in Serum"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22860-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22861-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22862-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22863-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22864-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11467-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "11468-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22109-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22859-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22865-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5055-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7814-7"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.761",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.761\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.761</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: MumpsTestPanelsformumpsvirusNucleicAcid</p><p><b>title</b>: Mumps (Test Panels for mumps virus Nucleic Acid)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Mumps (Test Panels for mumps virus Nucleic Acid)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 85808-4</p><p><b>display</b>: Mumps virus RNA and SH gene panel - Specimen by NAA with probe detection</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 93750-8</p><p><b>display</b>: Mumps virus RNA and N gene panel - Specimen</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 85808-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 93750-8</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.761",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.761"
+					}
+				],
+				"version": "1.0.0",
+				"name": "MumpsTestPanelsformumpsvirusNucleicAcid",
+				"title": "Mumps (Test Panels for mumps virus Nucleic Acid)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Mumps (Test Panels for mumps virus Nucleic Acid)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "36989005"
+								}
+							],
+							"text": "Mumps (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "85808-4",
+									"display": "Mumps virus RNA and SH gene panel - Specimen by NAA with probe detection"
+								},
+								{
+									"code": "93750-8",
+									"display": "Mumps virus RNA and N gene panel - Specimen"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "85808-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "93750-8"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1223",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1223\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1223</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: COVID_19TestsforSARS_CoV_2byCultureandIdentificationMethod</p><p><b>title</b>: COVID_19 (Tests for SARS_CoV_2 by Culture and Identification Method)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: COVID_19 (Tests for SARS_CoV_2 by Culture and Identification Method)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 94763-0</p><p><b>display</b>: SARS-CoV-2 (COVID-19) [Presence] in Specimen by Organism specific culture</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 94764-8</p><p><b>display</b>: SARS-CoV-2 (COVID-19) whole genome [Nucleotide sequence] in Isolate or Specimen by Sequencing</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 94763-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 94764-8</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1223",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1223"
+					}
+				],
+				"version": "1.0.0",
+				"name": "COVID_19TestsforSARS_CoV_2byCultureandIdentificationMethod",
+				"title": "COVID_19 (Tests for SARS_CoV_2 by Culture and Identification Method)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "COVID_19 (Tests for SARS_CoV_2 by Culture and Identification Method)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "840539006"
+								}
+							],
+							"text": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "94763-0",
+									"display": "SARS-CoV-2 (COVID-19) [Presence] in Specimen by Organism specific culture"
+								},
+								{
+									"code": "94764-8",
+									"display": "SARS-CoV-2 (COVID-19) whole genome [Nucleotide sequence] in Isolate or Specimen by Sequencing"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "94763-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "94764-8"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.762",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.762",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.762\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.762</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.762</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: MumpsTestPanelsformumpsvirusIgMIgGAntibody</p><p><b>title</b>: Mumps (Test Panels for mumps virus IgM IgG Antibody)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Mumps (Test Panels for mumps virus IgM IgG Antibody)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 77250-9</p><p><b>display</b>: Mumps virus IgG and IgM panel - Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 77398-6</p><p><b>display</b>: Mumps virus IgG and IgM index panel - Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 88458-5</p><p><b>display</b>: Mumps virus Ab.IgG and IgM panel - Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 92929-9</p><p><b>display</b>: Measles, Mumps and Rubella virus IgG panel [Units/volume] - Serum or Plasma</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 77250-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 77398-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 88458-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 92929-9</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.762",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.762"
+					}
+				],
+				"version": "1.0.0",
+				"name": "MumpsTestPanelsformumpsvirusIgMIgGAntibody",
+				"title": "Mumps (Test Panels for mumps virus IgM IgG Antibody)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Mumps (Test Panels for mumps virus IgM IgG Antibody)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "36989005"
+								}
+							],
+							"text": "Mumps (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "77250-9",
+									"display": "Mumps virus IgG and IgM panel - Serum"
+								},
+								{
+									"code": "77398-6",
+									"display": "Mumps virus IgG and IgM index panel - Serum"
+								},
+								{
+									"code": "88458-5",
+									"display": "Mumps virus Ab.IgG and IgM panel - Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "92929-9",
+									"display": "Measles, Mumps and Rubella virus IgG panel [Units/volume] - Serum or Plasma"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "77250-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "77398-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "88458-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "92929-9"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1182",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1182\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1182</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: PowassanVirusDiseaseTestsforPowassanVirusAntibodyQuantitative</p><p><b>title</b>: Powassan Virus Disease (Tests for Powassan Virus Antibody [Quantitative])</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Powassan Virus Disease (Tests for Powassan Virus Antibody [Quantitative])</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 29564-2</p><p><b>display</b>: Powassan virus IgG Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 30177-0</p><p><b>display</b>: Powassan virus IgG Ab [Titer] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31573-9</p><p><b>display</b>: Powassan virus IgG Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31574-7</p><p><b>display</b>: Powassan virus IgG Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40504-3</p><p><b>display</b>: Powassan virus Ab [Titer] in Serum by Complement fixation</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40513-4</p><p><b>display</b>: Powassan virus Ab [Titer] in Serum by Hemagglutination inhibition</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42973-8</p><p><b>display</b>: Powassan virus IgG Ab [Titer] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42974-6</p><p><b>display</b>: Powassan virus IgG Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42975-3</p><p><b>display</b>: Powassan virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95647-4</p><p><b>display</b>: Powassan virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 30179-6</p><p><b>display</b>: Powassan virus IgM Ab [Titer] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31575-4</p><p><b>display</b>: Powassan virus IgM Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31576-2</p><p><b>display</b>: Powassan virus IgM Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42971-2</p><p><b>display</b>: Powassan virus IgM Ab [Titer] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42972-0</p><p><b>display</b>: Powassan virus IgM Ab [Titer] in Serum</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29564-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30177-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31573-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31574-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40504-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40513-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42973-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42974-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42975-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95647-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30179-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31575-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31576-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42971-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42972-0</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1182",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1182"
+					}
+				],
+				"version": "1.0.0",
+				"name": "PowassanVirusDiseaseTestsforPowassanVirusAntibodyQuantitative",
+				"title": "Powassan Virus Disease (Tests for Powassan Virus Antibody [Quantitative])",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Powassan Virus Disease (Tests for Powassan Virus Antibody [Quantitative])",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "416707008"
+								}
+							],
+							"text": "Powassan encephalitis virus infection (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "29564-2",
+									"display": "Powassan virus IgG Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "30177-0",
+									"display": "Powassan virus IgG Ab [Titer] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "31573-9",
+									"display": "Powassan virus IgG Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "31574-7",
+									"display": "Powassan virus IgG Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "40504-3",
+									"display": "Powassan virus Ab [Titer] in Serum by Complement fixation"
+								},
+								{
+									"code": "40513-4",
+									"display": "Powassan virus Ab [Titer] in Serum by Hemagglutination inhibition"
+								},
+								{
+									"code": "42973-8",
+									"display": "Powassan virus IgG Ab [Titer] in Specimen"
+								},
+								{
+									"code": "42974-6",
+									"display": "Powassan virus IgG Ab [Titer] in Serum"
+								},
+								{
+									"code": "42975-3",
+									"display": "Powassan virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "95647-4",
+									"display": "Powassan virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "30179-6",
+									"display": "Powassan virus IgM Ab [Titer] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "31575-4",
+									"display": "Powassan virus IgM Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "31576-2",
+									"display": "Powassan virus IgM Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "42971-2",
+									"display": "Powassan virus IgM Ab [Titer] in Specimen"
+								},
+								{
+									"code": "42972-0",
+									"display": "Powassan virus IgM Ab [Titer] in Serum"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29564-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30177-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31573-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31574-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40504-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40513-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42973-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42974-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42975-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95647-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30179-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31575-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31576-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42971-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42972-0"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1181",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1181\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1181</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: EasternEquineEncephalitisVirusDiseaseTestsforEasternEquineEncephalitisVirusAntibodyQuantitative</p><p><b>title</b>: Eastern Equine Encephalitis Virus Disease (Tests for Eastern Equine Encephalitis Virus Antibody [Quantitative])</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Eastern Equine Encephalitis Virus Disease (Tests for Eastern Equine Encephalitis Virus Antibody [Quantitative])</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 10896-9</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 10897-7</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 13228-2</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 13918-8</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 20795-1</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22257-0</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22258-8</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22259-6</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 23042-5</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Hemagglutination inhibition</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24213-1</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence --1st specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24214-9</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence --2nd specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24287-5</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum --1st specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24288-3</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum --2nd specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 34723-7</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 38764-7</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43329-2</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Serum by Complement fixation</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 5134-2</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7860-0</p><p><b>display</b>: Eastern equine encephalitis virus IgG Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95654-0</p><p><b>display</b>: Eastern equine encephalitis virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 10898-5</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 10899-3</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 13229-0</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22260-4</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22261-2</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 38763-9</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43330-0</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Titer] in Serum by Immunoassay</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7861-8</p><p><b>display</b>: Eastern equine encephalitis virus IgM Ab [Units/volume] in Serum</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10896-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10897-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13228-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13918-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 20795-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22257-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22258-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22259-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 23042-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24213-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24214-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24287-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24288-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 34723-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 38764-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43329-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5134-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7860-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95654-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10898-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10899-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 13229-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22260-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22261-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 38763-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43330-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7861-8</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1181",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1181"
+					}
+				],
+				"version": "1.0.0",
+				"name": "EasternEquineEncephalitisVirusDiseaseTestsforEasternEquineEncephalitisVirusAntibodyQuantitative",
+				"title": "Eastern Equine Encephalitis Virus Disease (Tests for Eastern Equine Encephalitis Virus Antibody [Quantitative])",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Eastern Equine Encephalitis Virus Disease (Tests for Eastern Equine Encephalitis Virus Antibody [Quantitative])",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "416925005"
+								}
+							],
+							"text": "Eastern equine encephalitis virus infection (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "10896-9",
+									"display": "Eastern equine encephalitis virus IgG Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "10897-7",
+									"display": "Eastern equine encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "13228-2",
+									"display": "Eastern equine encephalitis virus IgG Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "13918-8",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "20795-1",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "22257-0",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "22258-8",
+									"display": "Eastern equine encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "22259-6",
+									"display": "Eastern equine encephalitis virus IgG Ab [Titer] in Serum"
+								},
+								{
+									"code": "23042-5",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Hemagglutination inhibition"
+								},
+								{
+									"code": "24213-1",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence --1st specimen"
+								},
+								{
+									"code": "24214-9",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Immunofluorescence --2nd specimen"
+								},
+								{
+									"code": "24287-5",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum --1st specimen"
+								},
+								{
+									"code": "24288-3",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum --2nd specimen"
+								},
+								{
+									"code": "34723-7",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "38764-7",
+									"display": "Eastern equine encephalitis virus IgG Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "43329-2",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Serum by Complement fixation"
+								},
+								{
+									"code": "5134-2",
+									"display": "Eastern equine encephalitis virus Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "7860-0",
+									"display": "Eastern equine encephalitis virus IgG Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "95654-0",
+									"display": "Eastern equine encephalitis virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "10898-5",
+									"display": "Eastern equine encephalitis virus IgM Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "10899-3",
+									"display": "Eastern equine encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "13229-0",
+									"display": "Eastern equine encephalitis virus IgM Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "22260-4",
+									"display": "Eastern equine encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "22261-2",
+									"display": "Eastern equine encephalitis virus IgM Ab [Titer] in Serum"
+								},
+								{
+									"code": "38763-9",
+									"display": "Eastern equine encephalitis virus IgM Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "43330-0",
+									"display": "Eastern equine encephalitis virus IgM Ab [Titer] in Serum by Immunoassay"
+								},
+								{
+									"code": "7861-8",
+									"display": "Eastern equine encephalitis virus IgM Ab [Units/volume] in Serum"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10896-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10897-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13228-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13918-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "20795-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22257-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22258-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22259-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "23042-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24213-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24214-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24287-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24288-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "34723-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "38764-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43329-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5134-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7860-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95654-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10898-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10899-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "13229-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22260-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22261-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "38763-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43330-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7861-8"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1184",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1184\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1184</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: CaliforniaSerogroupVirusDiseasesTestsforCaliforniaSerogroupVirusAntibodyQuantitative</p><p><b>title</b>: California Serogroup Virus Diseases (Tests for California Serogroup Virus Antibody [Quantitative])</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: California Serogroup Virus Diseases (Tests for California Serogroup Virus Antibody [Quantitative])</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><blockquote><p><b>concept</b></p><p><b>code</b>: 10904-1</p><p><b>display</b>: La Crosse virus IgG Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 17036-5</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 17037-3</p><p><b>display</b>: La Crosse virus Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 17038-1</p><p><b>display</b>: La Crosse virus IgG Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22373-5</p><p><b>display</b>: La Crosse virus IgG Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24209-9</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum by Immunofluorescence --1st specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24210-7</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum by Immunofluorescence --2nd specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24283-4</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum --1st specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 24284-2</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum --2nd specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29561-8</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29562-6</p><p><b>display</b>: Jamestown canyon virus Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29563-4</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29782-0</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29788-7</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29795-2</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Cerebral spinal fluid by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29801-8</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29808-3</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29814-1</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29821-6</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29827-3</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29834-9</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29839-8</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29846-3</p><p><b>display</b>: Trivittatus virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29851-3</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 30174-7</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Titer] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31446-8</p><p><b>display</b>: Jamestown canyon virus Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31448-4</p><p><b>display</b>: La Crosse virus Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31450-0</p><p><b>display</b>: La Crosse virus IgG Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31688-5</p><p><b>display</b>: Trivittatus virus Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31689-3</p><p><b>display</b>: Trivittatus virus Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31690-1</p><p><b>display</b>: Trivittatus virus Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 35694-9</p><p><b>display</b>: California encephalitis virus IgG Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 35696-4</p><p><b>display</b>: California encephalitis virus Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 35697-2</p><p><b>display</b>: La Crosse virus Ab [Titer] in Serum by Complement fixation</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 35709-5</p><p><b>display</b>: La Crosse virus Ab [Titer] in Body fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40506-8</p><p><b>display</b>: Jamestown canyon virus Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40507-6</p><p><b>display</b>: Jamestown canyon virus Ab [Titer] in Serum by Hemagglutination inhibition</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40510-0</p><p><b>display</b>: Snowshoe hare virus Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40511-8</p><p><b>display</b>: Snowshoe hare virus Ab [Titer] in Serum by Hemagglutination inhibition</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42952-2</p><p><b>display</b>: Snowshoe hare virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43004-1</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Titer] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43005-8</p><p><b>display</b>: Jamestown canyon virus IgG Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43006-6</p><p><b>display</b>: Jamestown canyon virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43132-0</p><p><b>display</b>: California encephalitis virus Ab [Units/volume] in Serum Qualitative</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43931-5</p><p><b>display</b>: California encephalitis virus Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 44746-6</p><p><b>display</b>: La Crosse virus Ab [Units/volume] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 44748-2</p><p><b>display</b>: La Crosse virus Ab [Units/volume] in Serum by Immunoassay</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 48716-5</p><p><b>display</b>: La Crosse virus IgG Ab [Units/volume] in Serum by Immunoassay</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49138-1</p><p><b>display</b>: California encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49140-7</p><p><b>display</b>: California encephalitis virus IgG Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49194-4</p><p><b>display</b>: California encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49195-1</p><p><b>display</b>: California encephalitis virus IgG Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 5073-2</p><p><b>display</b>: La Crosse virus Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7940-0</p><p><b>display</b>: La Crosse virus IgG Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 9538-0</p><p><b>display</b>: La Crosse virus Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 9539-8</p><p><b>display</b>: La Crosse virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95637-5</p><p><b>display</b>: Jamestown canyon virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95638-3</p><p><b>display</b>: California encephalitis virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95642-5</p><p><b>display</b>: Snowshoe hare virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 95653-2</p><p><b>display</b>: La Crosse virus Ab [Titer] in Specimen by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 10905-8</p><p><b>display</b>: La Crosse virus IgM Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 17039-9</p><p><b>display</b>: La Crosse virus IgM Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22375-0</p><p><b>display</b>: La Crosse virus IgM Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29786-1</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Specimen by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29799-4</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29812-5</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29825-7</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Specimen</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29837-2</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 29849-7</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 31451-8</p><p><b>display</b>: La Crosse virus IgM Ab [Units/volume] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 35695-6</p><p><b>display</b>: California encephalitis virus IgM Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40508-4</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 40509-2</p><p><b>display</b>: Snowshoe hare virus IgM Ab [Titer] in Serum by Neutralization test</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 42953-0</p><p><b>display</b>: Snowshoe hare virus IgM Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 43003-3</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Titer] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 44822-5</p><p><b>display</b>: La Crosse virus IgM Ab [Titer] in Serum by Immunoassay</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49139-9</p><p><b>display</b>: California encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49141-5</p><p><b>display</b>: California encephalitis virus IgM Ab [Titer] in Serum by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 49193-6</p><p><b>display</b>: California encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 62946-9</p><p><b>display</b>: Jamestown canyon virus IgM Ab [Titer] in Body fluid by Immunofluorescence</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 7941-8</p><p><b>display</b>: La Crosse virus IgM Ab [Units/volume] in Serum</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 9540-6</p><p><b>display</b>: La Crosse virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10904-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17036-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17037-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17038-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22373-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24209-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24210-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24283-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 24284-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29561-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29562-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29563-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29782-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29788-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29795-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29801-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29808-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29814-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29821-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29827-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29834-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29839-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29846-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29851-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 30174-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31446-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31448-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31450-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31688-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31689-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31690-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35694-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35696-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35697-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35709-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40506-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40507-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40510-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40511-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42952-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43004-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43005-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43006-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43132-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43931-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44746-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44748-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 48716-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49138-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49140-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49194-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49195-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 5073-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7940-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9538-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9539-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95637-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95638-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95642-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 95653-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 10905-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 17039-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 22375-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29786-1</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29799-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29812-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29825-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29837-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 29849-7</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 31451-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 35695-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40508-4</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 40509-2</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 42953-0</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 43003-3</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 44822-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49139-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49141-5</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 49193-6</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 62946-9</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 7941-8</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></p><p><b>version</b>: Provisional_2021-12-30</p><p><b>code</b>: 9540-6</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1184",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1184"
+					}
+				],
+				"version": "1.0.0",
+				"name": "CaliforniaSerogroupVirusDiseasesTestsforCaliforniaSerogroupVirusAntibodyQuantitative",
+				"title": "California Serogroup Virus Diseases (Tests for California Serogroup Virus Antibody [Quantitative])",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "California Serogroup Virus Diseases (Tests for California Serogroup Virus Antibody [Quantitative])",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "418182000"
+								}
+							],
+							"text": "Disease caused by California serogroup virus (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"concept": [
+								{
+									"code": "10904-1",
+									"display": "La Crosse virus IgG Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "17036-5",
+									"display": "La Crosse virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "17037-3",
+									"display": "La Crosse virus Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "17038-1",
+									"display": "La Crosse virus IgG Ab [Titer] in Serum"
+								},
+								{
+									"code": "22373-5",
+									"display": "La Crosse virus IgG Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "24209-9",
+									"display": "La Crosse virus Ab [Titer] in Serum by Immunofluorescence --1st specimen"
+								},
+								{
+									"code": "24210-7",
+									"display": "La Crosse virus Ab [Titer] in Serum by Immunofluorescence --2nd specimen"
+								},
+								{
+									"code": "24283-4",
+									"display": "La Crosse virus Ab [Titer] in Serum --1st specimen"
+								},
+								{
+									"code": "24284-2",
+									"display": "La Crosse virus Ab [Titer] in Serum --2nd specimen"
+								},
+								{
+									"code": "29561-8",
+									"display": "Jamestown canyon virus IgG Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "29562-6",
+									"display": "Jamestown canyon virus Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "29563-4",
+									"display": "La Crosse virus Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "29782-0",
+									"display": "Trivittatus virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "29788-7",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "29795-2",
+									"display": "Trivittatus virus Ab [Titer] in Cerebral spinal fluid by Neutralization test"
+								},
+								{
+									"code": "29801-8",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "29808-3",
+									"display": "Trivittatus virus Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "29814-1",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "29821-6",
+									"display": "Trivittatus virus Ab [Titer] in Specimen"
+								},
+								{
+									"code": "29827-3",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "29834-9",
+									"display": "Trivittatus virus Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "29839-8",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "29846-3",
+									"display": "Trivittatus virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "29851-3",
+									"display": "Jamestown canyon virus IgG Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "30174-7",
+									"display": "Jamestown canyon virus IgG Ab [Titer] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "31446-8",
+									"display": "Jamestown canyon virus Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "31448-4",
+									"display": "La Crosse virus Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "31450-0",
+									"display": "La Crosse virus IgG Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "31688-5",
+									"display": "Trivittatus virus Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "31689-3",
+									"display": "Trivittatus virus Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "31690-1",
+									"display": "Trivittatus virus Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "35694-9",
+									"display": "California encephalitis virus IgG Ab [Titer] in Serum"
+								},
+								{
+									"code": "35696-4",
+									"display": "California encephalitis virus Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "35697-2",
+									"display": "La Crosse virus Ab [Titer] in Serum by Complement fixation"
+								},
+								{
+									"code": "35709-5",
+									"display": "La Crosse virus Ab [Titer] in Body fluid"
+								},
+								{
+									"code": "40506-8",
+									"display": "Jamestown canyon virus Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "40507-6",
+									"display": "Jamestown canyon virus Ab [Titer] in Serum by Hemagglutination inhibition"
+								},
+								{
+									"code": "40510-0",
+									"display": "Snowshoe hare virus Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "40511-8",
+									"display": "Snowshoe hare virus Ab [Titer] in Serum by Hemagglutination inhibition"
+								},
+								{
+									"code": "42952-2",
+									"display": "Snowshoe hare virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "43004-1",
+									"display": "Jamestown canyon virus IgG Ab [Titer] in Specimen"
+								},
+								{
+									"code": "43005-8",
+									"display": "Jamestown canyon virus IgG Ab [Titer] in Serum"
+								},
+								{
+									"code": "43006-6",
+									"display": "Jamestown canyon virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "43132-0",
+									"display": "California encephalitis virus Ab [Units/volume] in Serum Qualitative"
+								},
+								{
+									"code": "43931-5",
+									"display": "California encephalitis virus Ab [Titer] in Serum"
+								},
+								{
+									"code": "44746-6",
+									"display": "La Crosse virus Ab [Units/volume] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "44748-2",
+									"display": "La Crosse virus Ab [Units/volume] in Serum by Immunoassay"
+								},
+								{
+									"code": "48716-5",
+									"display": "La Crosse virus IgG Ab [Units/volume] in Serum by Immunoassay"
+								},
+								{
+									"code": "49138-1",
+									"display": "California encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "49140-7",
+									"display": "California encephalitis virus IgG Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "49194-4",
+									"display": "California encephalitis virus IgG Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "49195-1",
+									"display": "California encephalitis virus IgG Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "5073-2",
+									"display": "La Crosse virus Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "7940-0",
+									"display": "La Crosse virus IgG Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "9538-0",
+									"display": "La Crosse virus Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "9539-8",
+									"display": "La Crosse virus IgG Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "95637-5",
+									"display": "Jamestown canyon virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "95638-3",
+									"display": "California encephalitis virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "95642-5",
+									"display": "Snowshoe hare virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "95653-2",
+									"display": "La Crosse virus Ab [Titer] in Specimen by Neutralization test"
+								},
+								{
+									"code": "10905-8",
+									"display": "La Crosse virus IgM Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "17039-9",
+									"display": "La Crosse virus IgM Ab [Titer] in Serum"
+								},
+								{
+									"code": "22375-0",
+									"display": "La Crosse virus IgM Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "29786-1",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Specimen by Immunofluorescence"
+								},
+								{
+									"code": "29799-4",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "29812-5",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "29825-7",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Specimen"
+								},
+								{
+									"code": "29837-2",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "29849-7",
+									"display": "Jamestown canyon virus IgM Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "31451-8",
+									"display": "La Crosse virus IgM Ab [Units/volume] in Cerebral spinal fluid"
+								},
+								{
+									"code": "35695-6",
+									"display": "California encephalitis virus IgM Ab [Titer] in Serum"
+								},
+								{
+									"code": "40508-4",
+									"display": "Jamestown canyon virus IgM Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "40509-2",
+									"display": "Snowshoe hare virus IgM Ab [Titer] in Serum by Neutralization test"
+								},
+								{
+									"code": "42953-0",
+									"display": "Snowshoe hare virus IgM Ab [Titer] in Serum"
+								},
+								{
+									"code": "43003-3",
+									"display": "Jamestown canyon virus IgM Ab [Titer] in Serum"
+								},
+								{
+									"code": "44822-5",
+									"display": "La Crosse virus IgM Ab [Titer] in Serum by Immunoassay"
+								},
+								{
+									"code": "49139-9",
+									"display": "California encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								},
+								{
+									"code": "49141-5",
+									"display": "California encephalitis virus IgM Ab [Titer] in Serum by Immunofluorescence"
+								},
+								{
+									"code": "49193-6",
+									"display": "California encephalitis virus IgM Ab [Titer] in Cerebral spinal fluid"
+								},
+								{
+									"code": "62946-9",
+									"display": "Jamestown canyon virus IgM Ab [Titer] in Body fluid by Immunofluorescence"
+								},
+								{
+									"code": "7941-8",
+									"display": "La Crosse virus IgM Ab [Units/volume] in Serum"
+								},
+								{
+									"code": "9540-6",
+									"display": "La Crosse virus IgM Ab [Titer] in Cerebral spinal fluid by Immunofluorescence"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10904-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17036-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17037-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17038-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22373-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24209-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24210-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24283-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "24284-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29561-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29562-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29563-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29782-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29788-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29795-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29801-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29808-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29814-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29821-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29827-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29834-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29839-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29846-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29851-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "30174-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31446-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31448-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31450-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31688-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31689-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31690-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35694-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35696-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35697-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35709-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40506-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40507-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40510-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40511-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42952-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43004-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43005-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43006-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43132-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43931-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44746-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44748-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "48716-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49138-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49140-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49194-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49195-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "5073-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7940-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9538-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9539-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95637-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95638-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95642-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "95653-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "10905-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "17039-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "22375-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29786-1"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29799-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29812-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29825-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29837-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "29849-7"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "31451-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "35695-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40508-4"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "40509-2"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "42953-0"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "43003-3"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "44822-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49139-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49141-5"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "49193-6"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "62946-9"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "7941-8"
+						},
+						{
+							"system": "http://loinc.org",
+							"version": "Provisional_2021-12-30",
+							"code": "9540-6"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1601",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1601\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1601</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HIVInfectionARVBoostersCYP3A4InhibitorRXNORM</p><p><b>title</b>: HIV Infection (ARV Boosters [CYP3A4 Inhibitor]) (RXNORM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: HIV Infection (ARV Boosters [CYP3A4 Inhibitor]) (RXNORM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><blockquote><p><b>concept</b></p><p><b>code</b>: 1551993</p><p><b>display</b>: cobicistat 150 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1551999</p><p><b>display</b>: cobicistat 150 MG Oral Tablet [Tybost]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 152970</p><p><b>display</b>: ritonavir 100 MG Oral Capsule [Norvir]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 152971</p><p><b>display</b>: ritonavir 80 MG/ML Oral Solution [Norvir]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1926066</p><p><b>display</b>: ritonavir 100 MG Oral Powder</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1926069</p><p><b>display</b>: ritonavir 100 MG Oral Powder [Norvir]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 199249</p><p><b>display</b>: ritonavir 80 MG/ML Oral Solution</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 317150</p><p><b>display</b>: ritonavir 100 MG Oral Capsule</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 900575</p><p><b>display</b>: ritonavir 100 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 900577</p><p><b>display</b>: ritonavir 100 MG Oral Tablet [Norvir]</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1551993</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1551999</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 152970</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 152971</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1926066</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1926069</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 199249</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 317150</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 900575</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 900577</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1601",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1601"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HIVInfectionARVBoostersCYP3A4InhibitorRXNORM",
+				"title": "HIV Infection (ARV Boosters [CYP3A4 Inhibitor]) (RXNORM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "HIV Infection (ARV Boosters [CYP3A4 Inhibitor]) (RXNORM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "76981000119106"
+								}
+							],
+							"text": "Human immunodeficiency virus (HIV) infection category B1 (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"concept": [
+								{
+									"code": "1551993",
+									"display": "cobicistat 150 MG Oral Tablet"
+								},
+								{
+									"code": "1551999",
+									"display": "cobicistat 150 MG Oral Tablet [Tybost]"
+								},
+								{
+									"code": "152970",
+									"display": "ritonavir 100 MG Oral Capsule [Norvir]"
+								},
+								{
+									"code": "152971",
+									"display": "ritonavir 80 MG/ML Oral Solution [Norvir]"
+								},
+								{
+									"code": "1926066",
+									"display": "ritonavir 100 MG Oral Powder"
+								},
+								{
+									"code": "1926069",
+									"display": "ritonavir 100 MG Oral Powder [Norvir]"
+								},
+								{
+									"code": "199249",
+									"display": "ritonavir 80 MG/ML Oral Solution"
+								},
+								{
+									"code": "317150",
+									"display": "ritonavir 100 MG Oral Capsule"
+								},
+								{
+									"code": "900575",
+									"display": "ritonavir 100 MG Oral Tablet"
+								},
+								{
+									"code": "900577",
+									"display": "ritonavir 100 MG Oral Tablet [Norvir]"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1551993"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1551999"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "152970"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "152971"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1926066"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1926069"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "199249"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "317150"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "900575"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "900577"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1600",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1600\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1600</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HIVInfectionARVIntegraseStrandTransferInhibitorsINSTIsRXNORM</p><p><b>title</b>: HIV Infection (ARV Integrase Strand Transfer Inhibitors [INSTIs]) (RXNORM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: HIV Infection (ARV Integrase Strand Transfer Inhibitors [INSTIs]) (RXNORM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><blockquote><p><b>concept</b></p><p><b>code</b>: 1235588</p><p><b>display</b>: raltegravir 100 MG Chewable Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1235591</p><p><b>display</b>: raltegravir 100 MG Chewable Tablet [Isentress]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1235593</p><p><b>display</b>: raltegravir 25 MG Chewable Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1235595</p><p><b>display</b>: raltegravir 25 MG Chewable Tablet [Isentress]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1433873</p><p><b>display</b>: dolutegravir 50 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1433879</p><p><b>display</b>: dolutegravir 50 MG Oral Tablet [Tivicay]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1486838</p><p><b>display</b>: raltegravir 100 MG Granules for Oral Suspension</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1486841</p><p><b>display</b>: raltegravir 100 MG Granules for Oral Suspension [Isentress]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1796077</p><p><b>display</b>: dolutegravir 10 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1796079</p><p><b>display</b>: dolutegravir 10 MG Oral Tablet [Tivicay]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1796081</p><p><b>display</b>: dolutegravir 25 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1796083</p><p><b>display</b>: dolutegravir 25 MG Oral Tablet [Tivicay]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1924313</p><p><b>display</b>: raltegravir 600 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1924315</p><p><b>display</b>: raltegravir 600 MG Oral Tablet [Isentress]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2374562</p><p><b>display</b>: dolutegravir 5 MG Tablet for Oral Suspension</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2374566</p><p><b>display</b>: dolutegravir 5 MG Tablet for Oral Suspension [Tivicay]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2475199</p><p><b>display</b>: cabotegravir 30 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2475205</p><p><b>display</b>: cabotegravir 30 MG Oral Tablet [Vocabria]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 744842</p><p><b>display</b>: raltegravir 400 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 744846</p><p><b>display</b>: raltegravir 400 MG Oral Tablet [Isentress]</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1999667</p><p><b>display</b>: bictegravir 50 MG / emtricitabine 200 MG / tenofovir alafenamide 25 MG Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 1999673</p><p><b>display</b>: bictegravir 50 MG / emtricitabine 200 MG / tenofovir alafenamide 25 MG Oral Tablet [Biktarvy]</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235588</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235591</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235593</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1235595</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1433873</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1433879</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1486838</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1486841</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796077</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796079</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796081</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1796083</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1924313</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1924315</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2374562</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2374566</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2475199</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2475205</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 744842</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 744846</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1999667</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 1999673</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1600",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1600"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HIVInfectionARVIntegraseStrandTransferInhibitorsINSTIsRXNORM",
+				"title": "HIV Infection (ARV Integrase Strand Transfer Inhibitors [INSTIs]) (RXNORM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "HIV Infection (ARV Integrase Strand Transfer Inhibitors [INSTIs]) (RXNORM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "76981000119106"
+								}
+							],
+							"text": "Human immunodeficiency virus (HIV) infection category B1 (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"concept": [
+								{
+									"code": "1235588",
+									"display": "raltegravir 100 MG Chewable Tablet"
+								},
+								{
+									"code": "1235591",
+									"display": "raltegravir 100 MG Chewable Tablet [Isentress]"
+								},
+								{
+									"code": "1235593",
+									"display": "raltegravir 25 MG Chewable Tablet"
+								},
+								{
+									"code": "1235595",
+									"display": "raltegravir 25 MG Chewable Tablet [Isentress]"
+								},
+								{
+									"code": "1433873",
+									"display": "dolutegravir 50 MG Oral Tablet"
+								},
+								{
+									"code": "1433879",
+									"display": "dolutegravir 50 MG Oral Tablet [Tivicay]"
+								},
+								{
+									"code": "1486838",
+									"display": "raltegravir 100 MG Granules for Oral Suspension"
+								},
+								{
+									"code": "1486841",
+									"display": "raltegravir 100 MG Granules for Oral Suspension [Isentress]"
+								},
+								{
+									"code": "1796077",
+									"display": "dolutegravir 10 MG Oral Tablet"
+								},
+								{
+									"code": "1796079",
+									"display": "dolutegravir 10 MG Oral Tablet [Tivicay]"
+								},
+								{
+									"code": "1796081",
+									"display": "dolutegravir 25 MG Oral Tablet"
+								},
+								{
+									"code": "1796083",
+									"display": "dolutegravir 25 MG Oral Tablet [Tivicay]"
+								},
+								{
+									"code": "1924313",
+									"display": "raltegravir 600 MG Oral Tablet"
+								},
+								{
+									"code": "1924315",
+									"display": "raltegravir 600 MG Oral Tablet [Isentress]"
+								},
+								{
+									"code": "2374562",
+									"display": "dolutegravir 5 MG Tablet for Oral Suspension"
+								},
+								{
+									"code": "2374566",
+									"display": "dolutegravir 5 MG Tablet for Oral Suspension [Tivicay]"
+								},
+								{
+									"code": "2475199",
+									"display": "cabotegravir 30 MG Oral Tablet"
+								},
+								{
+									"code": "2475205",
+									"display": "cabotegravir 30 MG Oral Tablet [Vocabria]"
+								},
+								{
+									"code": "744842",
+									"display": "raltegravir 400 MG Oral Tablet"
+								},
+								{
+									"code": "744846",
+									"display": "raltegravir 400 MG Oral Tablet [Isentress]"
+								},
+								{
+									"code": "1999667",
+									"display": "bictegravir 50 MG / emtricitabine 200 MG / tenofovir alafenamide 25 MG Oral Tablet"
+								},
+								{
+									"code": "1999673",
+									"display": "bictegravir 50 MG / emtricitabine 200 MG / tenofovir alafenamide 25 MG Oral Tablet [Biktarvy]"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235588"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235591"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235593"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1235595"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1433873"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1433879"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1486838"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1486841"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796077"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796079"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796081"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1796083"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1924313"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1924315"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2374562"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2374566"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2475199"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2475205"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "744842"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "744846"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1999667"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "1999673"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1603",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1603\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1603</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HIVInfectionARVAttachmentInhibitorsRXNORM</p><p><b>title</b>: HIV Infection (ARV Attachment Inhibitors) (RXNORM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: HIV Infection (ARV Attachment Inhibitors) (RXNORM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><blockquote><p><b>concept</b></p><p><b>code</b>: 2380549</p><p><b>display</b>: 12 HR fostemsavir 600 MG Extended Release Oral Tablet</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2380551</p><p><b>display</b>: 12 HR fostemsavir 600 MG Extended Release Oral Tablet [Rukobia]</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2380549</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2380551</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1603",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1603"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HIVInfectionARVAttachmentInhibitorsRXNORM",
+				"title": "HIV Infection (ARV Attachment Inhibitors) (RXNORM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "HIV Infection (ARV Attachment Inhibitors) (RXNORM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "76981000119106"
+								}
+							],
+							"text": "Human immunodeficiency virus (HIV) infection category B1 (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"concept": [
+								{
+									"code": "2380549",
+									"display": "12 HR fostemsavir 600 MG Extended Release Oral Tablet"
+								},
+								{
+									"code": "2380551",
+									"display": "12 HR fostemsavir 600 MG Extended Release Oral Tablet [Rukobia]"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2380549"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2380551"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1602",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1602\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1602</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HIVInfectionARVPostattachmentInhibitorsRXNORM</p><p><b>title</b>: HIV Infection (ARV Postattachment Inhibitors) (RXNORM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: HIV Infection (ARV Postattachment Inhibitors) (RXNORM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><blockquote><p><b>concept</b></p><p><b>code</b>: 2043317</p><p><b>display</b>: 1.33 ML ibalizumab-uiyk 150 MG/ML Injection</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 2043322</p><p><b>display</b>: 1.33 ML ibalizumab-uiyk 150 MG/ML Injection [Trogarzo]</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2043317</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 2043322</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1602",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1602"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HIVInfectionARVPostattachmentInhibitorsRXNORM",
+				"title": "HIV Infection (ARV Postattachment Inhibitors) (RXNORM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "HIV Infection (ARV Postattachment Inhibitors) (RXNORM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "76981000119106"
+								}
+							],
+							"text": "Human immunodeficiency virus (HIV) infection category B1 (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"concept": [
+								{
+									"code": "2043317",
+									"display": "1.33 ML ibalizumab-uiyk 150 MG/ML Injection"
+								},
+								{
+									"code": "2043322",
+									"display": "1.33 ML ibalizumab-uiyk 150 MG/ML Injection [Trogarzo]"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2043317"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "2043322"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1082",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1082\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1082</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: AnthraxVaccineRXNORM</p><p><b>title</b>: Anthrax Vaccine (RXNORM)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Anthrax Vaccine (RXNORM)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><blockquote><p><b>concept</b></p><p><b>code</b>: 832679</p><p><b>display</b>: Bacillus anthracis strain V770-NP1-R antigens 0.1 MG/ML Injectable Suspension</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 832682</p><p><b>display</b>: Bacillus anthracis strain V770-NP1-R antigens 0.1 MG/ML Injectable Suspension [Biothrax]</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 832679</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></p><p><b>version</b>: 2022-01</p><p><b>code</b>: 832682</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1082",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1082"
+					}
+				],
+				"version": "1.0.0",
+				"name": "AnthraxVaccineRXNORM",
+				"title": "Anthrax Vaccine (RXNORM)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Anthrax Vaccine (RXNORM)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "409498004"
+								}
+							],
+							"text": "Anthrax (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"concept": [
+								{
+									"code": "832679",
+									"display": "Bacillus anthracis strain V770-NP1-R antigens 0.1 MG/ML Injectable Suspension"
+								},
+								{
+									"code": "832682",
+									"display": "Bacillus anthracis strain V770-NP1-R antigens 0.1 MG/ML Injectable Suspension [Biothrax]"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "832679"
+						},
+						{
+							"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+							"version": "2022-01",
+							"code": "832682"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.528",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.528\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.528</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: DengueVirusInfectionOrganismorSubstanceinLabResults</p><p><b>title</b>: Dengue Virus Infection (Organism or Substance in Lab Results)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Dengue Virus Infection (Organism or Substance in Lab Results)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 121020003</p><p><b>display</b>: Antigen of Dengue virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 121182007</p><p><b>display</b>: Deoxyribonucleic acid of Dengue virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 121192004</p><p><b>display</b>: Dengue virus types 1-4 ribonucleic acid (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 243604005</p><p><b>display</b>: Dengue virus subgroup (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 34348001</p><p><b>display</b>: Dengue virus (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 36700002</p><p><b>display</b>: Dengue virus, type 4 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 41328007</p><p><b>display</b>: Dengue virus, type 2 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 60588009</p><p><b>display</b>: Dengue virus, type 1 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707875002</p><p><b>display</b>: Ribonucleic acid of Dengue virus 1 (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707876001</p><p><b>display</b>: Ribonucleic acid of Dengue virus 2 (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707877005</p><p><b>display</b>: Ribonucleic acid of Dengue virus 3 (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707878000</p><p><b>display</b>: Ribonucleic acid of Dengue virus 4 (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 783725005</p><p><b>display</b>: Ribonucleic acid of Dengue virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 8467002</p><p><b>display</b>: Dengue virus, type 3 (organism)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121020003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121182007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121192004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 243604005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 34348001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 36700002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 41328007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 60588009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707875002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707876001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707877005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707878000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 783725005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 8467002</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.528",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.528"
+					}
+				],
+				"version": "1.0.0",
+				"name": "DengueVirusInfectionOrganismorSubstanceinLabResults",
+				"title": "Dengue Virus Infection (Organism or Substance in Lab Results)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Dengue Virus Infection (Organism or Substance in Lab Results)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "38362002"
+								}
+							],
+							"text": "Dengue (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "121020003",
+									"display": "Antigen of Dengue virus (substance)"
+								},
+								{
+									"code": "121182007",
+									"display": "Deoxyribonucleic acid of Dengue virus (substance)"
+								},
+								{
+									"code": "121192004",
+									"display": "Dengue virus types 1-4 ribonucleic acid (substance)"
+								},
+								{
+									"code": "243604005",
+									"display": "Dengue virus subgroup (organism)"
+								},
+								{
+									"code": "34348001",
+									"display": "Dengue virus (organism)"
+								},
+								{
+									"code": "36700002",
+									"display": "Dengue virus, type 4 (organism)"
+								},
+								{
+									"code": "41328007",
+									"display": "Dengue virus, type 2 (organism)"
+								},
+								{
+									"code": "60588009",
+									"display": "Dengue virus, type 1 (organism)"
+								},
+								{
+									"code": "707875002",
+									"display": "Ribonucleic acid of Dengue virus 1 (substance)"
+								},
+								{
+									"code": "707876001",
+									"display": "Ribonucleic acid of Dengue virus 2 (substance)"
+								},
+								{
+									"code": "707877005",
+									"display": "Ribonucleic acid of Dengue virus 3 (substance)"
+								},
+								{
+									"code": "707878000",
+									"display": "Ribonucleic acid of Dengue virus 4 (substance)"
+								},
+								{
+									"code": "783725005",
+									"display": "Ribonucleic acid of Dengue virus (substance)"
+								},
+								{
+									"code": "8467002",
+									"display": "Dengue virus, type 3 (organism)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121020003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121182007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121192004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "243604005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "34348001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "36700002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "41328007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "60588009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707875002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707876001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707877005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707878000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "783725005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "8467002"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.408",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.408\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.408</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HepatitisBVirusInfectionOrganismorSubstanceinLabResults</p><p><b>title</b>: Hepatitis B Virus Infection (Organism or Substance in Lab Results)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Hepatitis B Virus Infection (Organism or Substance in Lab Results)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 121112003</p><p><b>display</b>: Deoxyribonucleic acid of Hepatitis B virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 121184008</p><p><b>display</b>: Ribosomal ribonucleic acid of Hepatitis B virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 13105002</p><p><b>display</b>: Antigen of Hepatitis B virus subtype ayr surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 22290004</p><p><b>display</b>: Antigen of Hepatitis B virus surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 303233001</p><p><b>display</b>: Antigen of Hepatitis B virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 39082004</p><p><b>display</b>: Antigen of Hepatitis B virus core protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 52680001</p><p><b>display</b>: Antigen of Hepatitis B virus subtype adr surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 60605004</p><p><b>display</b>: Antigen of Hepatitis B virus e protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 63350005</p><p><b>display</b>: Antigen of Hepatitis B virus subtype adw surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703886001</p><p><b>display</b>: Hepatitis B virus genotype A (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703887005</p><p><b>display</b>: Hepatitis B virus genotype B (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703888000</p><p><b>display</b>: Hepatitis B virus genotype C (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703889008</p><p><b>display</b>: Hepatitis B virus genotype D (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703890004</p><p><b>display</b>: Hepatitis B virus genotype E (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703891000</p><p><b>display</b>: Hepatitis B virus genotype F (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703892007</p><p><b>display</b>: Hepatitis B virus genotype G (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703893002</p><p><b>display</b>: Hepatitis B virus genotype H (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 708281003</p><p><b>display</b>: Deoxyribonucleic acid of Hepatitis B virus polymerase (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 716076002</p><p><b>display</b>: Antigen of Hepatitis B virus recombinant surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 73661005</p><p><b>display</b>: Antigen of Hepatitis B virus subtype ayw surface protein (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 81665004</p><p><b>display</b>: Hepatitis B virus (organism)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121112003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121184008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 13105002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 22290004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 303233001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 39082004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 52680001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 60605004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 63350005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703886001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703887005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703888000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703889008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703890004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703891000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703892007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703893002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708281003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 716076002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 73661005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 81665004</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.408",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.408"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HepatitisBVirusInfectionOrganismorSubstanceinLabResults",
+				"title": "Hepatitis B Virus Infection (Organism or Substance in Lab Results)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Hepatitis B Virus Infection (Organism or Substance in Lab Results)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "66071002"
+								}
+							],
+							"text": "Viral hepatitis type B (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "60498001"
+								}
+							],
+							"text": "Congenital viral hepatitis B infection (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "121112003",
+									"display": "Deoxyribonucleic acid of Hepatitis B virus (substance)"
+								},
+								{
+									"code": "121184008",
+									"display": "Ribosomal ribonucleic acid of Hepatitis B virus (substance)"
+								},
+								{
+									"code": "13105002",
+									"display": "Antigen of Hepatitis B virus subtype ayr surface protein (substance)"
+								},
+								{
+									"code": "22290004",
+									"display": "Antigen of Hepatitis B virus surface protein (substance)"
+								},
+								{
+									"code": "303233001",
+									"display": "Antigen of Hepatitis B virus (substance)"
+								},
+								{
+									"code": "39082004",
+									"display": "Antigen of Hepatitis B virus core protein (substance)"
+								},
+								{
+									"code": "52680001",
+									"display": "Antigen of Hepatitis B virus subtype adr surface protein (substance)"
+								},
+								{
+									"code": "60605004",
+									"display": "Antigen of Hepatitis B virus e protein (substance)"
+								},
+								{
+									"code": "63350005",
+									"display": "Antigen of Hepatitis B virus subtype adw surface protein (substance)"
+								},
+								{
+									"code": "703886001",
+									"display": "Hepatitis B virus genotype A (organism)"
+								},
+								{
+									"code": "703887005",
+									"display": "Hepatitis B virus genotype B (organism)"
+								},
+								{
+									"code": "703888000",
+									"display": "Hepatitis B virus genotype C (organism)"
+								},
+								{
+									"code": "703889008",
+									"display": "Hepatitis B virus genotype D (organism)"
+								},
+								{
+									"code": "703890004",
+									"display": "Hepatitis B virus genotype E (organism)"
+								},
+								{
+									"code": "703891000",
+									"display": "Hepatitis B virus genotype F (organism)"
+								},
+								{
+									"code": "703892007",
+									"display": "Hepatitis B virus genotype G (organism)"
+								},
+								{
+									"code": "703893002",
+									"display": "Hepatitis B virus genotype H (organism)"
+								},
+								{
+									"code": "708281003",
+									"display": "Deoxyribonucleic acid of Hepatitis B virus polymerase (substance)"
+								},
+								{
+									"code": "716076002",
+									"display": "Antigen of Hepatitis B virus recombinant surface protein (substance)"
+								},
+								{
+									"code": "73661005",
+									"display": "Antigen of Hepatitis B virus subtype ayw surface protein (substance)"
+								},
+								{
+									"code": "81665004",
+									"display": "Hepatitis B virus (organism)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121112003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121184008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "13105002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "22290004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "303233001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "39082004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "52680001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "60605004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "63350005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703886001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703887005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703888000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703889008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703890004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703891000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703892007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703893002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708281003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "716076002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "73661005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "81665004"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.409",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.409\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.409</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: HepatitisCVirusInfectionOrganismorSubstanceinLabResults</p><p><b>title</b>: Hepatitis C Virus Infection (Organism or Substance in Lab Results)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Hepatitis C Virus Infection (Organism or Substance in Lab Results)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 121022006</p><p><b>display</b>: Antigen of Hepacivirus C (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 121185009</p><p><b>display</b>: Ribosomal ribonucleic acid of Hepatitis C virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 121204002</p><p><b>display</b>: Ribonucleic acid of Hepatitis C virus (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 371140008</p><p><b>display</b>: Polymerase chain reaction positive for hepatitis C viral ribonucleic acid genotype 1A (finding)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603413005</p><p><b>display</b>: Hepatitis C virus subtype 1a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603414004</p><p><b>display</b>: Hepatitis C virus subtype 1b (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603415003</p><p><b>display</b>: Hepatitis C virus subtype 2a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603416002</p><p><b>display</b>: Hepatitis C virus subtype 2b (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603417006</p><p><b>display</b>: Hepatitis C virus subtype 3a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603418001</p><p><b>display</b>: Hepatitis C virus subtype 3b (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603419009</p><p><b>display</b>: Hepatitis C virus subtype 5a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603420003</p><p><b>display</b>: Hepatitis C virus subtype 6a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603421004</p><p><b>display</b>: Hepatitis C virus subtype 4a (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603422006</p><p><b>display</b>: Hepatitis C virus genotype 1 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603423001</p><p><b>display</b>: Hepatitis C virus genotype 2 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603424007</p><p><b>display</b>: Hepatitis C virus genotype 3 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603425008</p><p><b>display</b>: Hepatitis C virus genotype 4 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603426009</p><p><b>display</b>: Hepatitis C virus genotype 5 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603427000</p><p><b>display</b>: Hepatitis C virus genotype 6 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603428005</p><p><b>display</b>: Hepatitis C virus subtype 1c (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603429002</p><p><b>display</b>: Hepatitis C virus subtype 2c (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603430007</p><p><b>display</b>: Hepatitis C virus subtype 4b (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603431006</p><p><b>display</b>: Hepatitis C virus subtype 4c (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603432004</p><p><b>display</b>: Hepatitis C virus subtype 4d (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 603433009</p><p><b>display</b>: Hepatitis C virus subtype 4e (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 62944002</p><p><b>display</b>: Hepatitis C virus (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 711331006</p><p><b>display</b>: Polymerase chain reaction test for Hepatitis C positive (finding)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 726592002</p><p><b>display</b>: Antigen of Hepatitis C virus core (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 781245007</p><p><b>display</b>: Hepatitis C virus genotype 4h (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 781276001</p><p><b>display</b>: Hepatitis C virus genotype 3c (organism)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121022006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121185009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 121204002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 371140008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603413005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603414004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603415003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603416002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603417006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603418001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603419009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603420003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603421004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603422006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603423001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603424007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603425008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603426009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603427000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603428005</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603429002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603430007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603431006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603432004</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 603433009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 62944002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 711331006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 726592002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 781245007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 781276001</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.409",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.409"
+					}
+				],
+				"version": "1.0.0",
+				"name": "HepatitisCVirusInfectionOrganismorSubstanceinLabResults",
+				"title": "Hepatitis C Virus Infection (Organism or Substance in Lab Results)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Hepatitis C Virus Infection (Organism or Substance in Lab Results)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "50711007"
+								}
+							],
+							"text": "Viral hepatitis type C (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "121022006",
+									"display": "Antigen of Hepacivirus C (substance)"
+								},
+								{
+									"code": "121185009",
+									"display": "Ribosomal ribonucleic acid of Hepatitis C virus (substance)"
+								},
+								{
+									"code": "121204002",
+									"display": "Ribonucleic acid of Hepatitis C virus (substance)"
+								},
+								{
+									"code": "371140008",
+									"display": "Polymerase chain reaction positive for hepatitis C viral ribonucleic acid genotype 1A (finding)"
+								},
+								{
+									"code": "603413005",
+									"display": "Hepatitis C virus subtype 1a (organism)"
+								},
+								{
+									"code": "603414004",
+									"display": "Hepatitis C virus subtype 1b (organism)"
+								},
+								{
+									"code": "603415003",
+									"display": "Hepatitis C virus subtype 2a (organism)"
+								},
+								{
+									"code": "603416002",
+									"display": "Hepatitis C virus subtype 2b (organism)"
+								},
+								{
+									"code": "603417006",
+									"display": "Hepatitis C virus subtype 3a (organism)"
+								},
+								{
+									"code": "603418001",
+									"display": "Hepatitis C virus subtype 3b (organism)"
+								},
+								{
+									"code": "603419009",
+									"display": "Hepatitis C virus subtype 5a (organism)"
+								},
+								{
+									"code": "603420003",
+									"display": "Hepatitis C virus subtype 6a (organism)"
+								},
+								{
+									"code": "603421004",
+									"display": "Hepatitis C virus subtype 4a (organism)"
+								},
+								{
+									"code": "603422006",
+									"display": "Hepatitis C virus genotype 1 (organism)"
+								},
+								{
+									"code": "603423001",
+									"display": "Hepatitis C virus genotype 2 (organism)"
+								},
+								{
+									"code": "603424007",
+									"display": "Hepatitis C virus genotype 3 (organism)"
+								},
+								{
+									"code": "603425008",
+									"display": "Hepatitis C virus genotype 4 (organism)"
+								},
+								{
+									"code": "603426009",
+									"display": "Hepatitis C virus genotype 5 (organism)"
+								},
+								{
+									"code": "603427000",
+									"display": "Hepatitis C virus genotype 6 (organism)"
+								},
+								{
+									"code": "603428005",
+									"display": "Hepatitis C virus subtype 1c (organism)"
+								},
+								{
+									"code": "603429002",
+									"display": "Hepatitis C virus subtype 2c (organism)"
+								},
+								{
+									"code": "603430007",
+									"display": "Hepatitis C virus subtype 4b (organism)"
+								},
+								{
+									"code": "603431006",
+									"display": "Hepatitis C virus subtype 4c (organism)"
+								},
+								{
+									"code": "603432004",
+									"display": "Hepatitis C virus subtype 4d (organism)"
+								},
+								{
+									"code": "603433009",
+									"display": "Hepatitis C virus subtype 4e (organism)"
+								},
+								{
+									"code": "62944002",
+									"display": "Hepatitis C virus (organism)"
+								},
+								{
+									"code": "711331006",
+									"display": "Polymerase chain reaction test for Hepatitis C positive (finding)"
+								},
+								{
+									"code": "726592002",
+									"display": "Antigen of Hepatitis C virus core (substance)"
+								},
+								{
+									"code": "781245007",
+									"display": "Hepatitis C virus genotype 4h (organism)"
+								},
+								{
+									"code": "781276001",
+									"display": "Hepatitis C virus genotype 3c (organism)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121022006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121185009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "121204002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "371140008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603413005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603414004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603415003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603416002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603417006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603418001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603419009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603420003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603421004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603422006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603423001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603424007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603425008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603426009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603427000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603428005"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603429002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603430007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603431006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603432004"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "603433009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "62944002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "711331006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "726592002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "781245007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "781276001"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1469",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1469\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1469</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: EnterococcusfaeciumorEfaecalisOrganismorSubstanceinLabResults</p><p><b>title</b>: Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 416397000</p><p><b>display</b>: Enterococcus faecalis variant (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 708244002</p><p><b>display</b>: Deoxyribonucleic acid of Enterococcus faecalis (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 708245001</p><p><b>display</b>: Deoxyribonucleic acid of Enterococcus faecium (substance)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 712664000</p><p><b>display</b>: Vancomycin intermediate Enterococcus faecalis (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 712666003</p><p><b>display</b>: Vancomycin intermediate Enterococcus faecium (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 78065002</p><p><b>display</b>: Enterococcus faecalis (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 782956001</p><p><b>display</b>: Vancomycin susceptible Enterococcus faecium (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 782958000</p><p><b>display</b>: Vancomycin susceptible Enterococcus faecalis (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 90272000</p><p><b>display</b>: Enterococcus faecium (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 928051771000087103</p><p><b>display</b>: Enterococcus faecalis type 2 (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707768008</p><p><b>display</b>: Enterococcus faecium genotype vanA (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 707769000</p><p><b>display</b>: Enterococcus faecium genotype vanB (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 712663006</p><p><b>display</b>: Vancomycin resistant Enterococcus faecalis (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 712665004</p><p><b>display</b>: Vancomycin resistant Enterococcus faecium (organism)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 416397000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708244002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 708245001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712664000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712666003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 78065002</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 782956001</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 782958000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 90272000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 928051771000087103</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707768008</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 707769000</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712663006</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 712665004</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1469",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1469"
+					}
+				],
+				"version": "1.0.0",
+				"name": "EnterococcusfaeciumorEfaecalisOrganismorSubstanceinLabResults",
+				"title": "Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Enterococcus faecium or E. faecalis (Organism or Substance in Lab Results)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "406575008"
+								}
+							],
+							"text": "Infection caused by vancomycin resistant enterococcus (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "416397000",
+									"display": "Enterococcus faecalis variant (organism)"
+								},
+								{
+									"code": "708244002",
+									"display": "Deoxyribonucleic acid of Enterococcus faecalis (substance)"
+								},
+								{
+									"code": "708245001",
+									"display": "Deoxyribonucleic acid of Enterococcus faecium (substance)"
+								},
+								{
+									"code": "712664000",
+									"display": "Vancomycin intermediate Enterococcus faecalis (organism)"
+								},
+								{
+									"code": "712666003",
+									"display": "Vancomycin intermediate Enterococcus faecium (organism)"
+								},
+								{
+									"code": "78065002",
+									"display": "Enterococcus faecalis (organism)"
+								},
+								{
+									"code": "782956001",
+									"display": "Vancomycin susceptible Enterococcus faecium (organism)"
+								},
+								{
+									"code": "782958000",
+									"display": "Vancomycin susceptible Enterococcus faecalis (organism)"
+								},
+								{
+									"code": "90272000",
+									"display": "Enterococcus faecium (organism)"
+								},
+								{
+									"code": "928051771000087103",
+									"display": "Enterococcus faecalis type 2 (organism)"
+								},
+								{
+									"code": "707768008",
+									"display": "Enterococcus faecium genotype vanA (organism)"
+								},
+								{
+									"code": "707769000",
+									"display": "Enterococcus faecium genotype vanB (organism)"
+								},
+								{
+									"code": "712663006",
+									"display": "Vancomycin resistant Enterococcus faecalis (organism)"
+								},
+								{
+									"code": "712665004",
+									"display": "Vancomycin resistant Enterococcus faecium (organism)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "416397000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708244002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "708245001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712664000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712666003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "78065002"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "782956001"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "782958000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "90272000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "928051771000087103"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707768008"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "707769000"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712663006"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "712665004"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1468",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1468",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1468\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1468</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1468</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: EnterococcusgallinarumorEcasseliflavusEflavescensOrganismorSubstanceinLabResults</p><p><b>title</b>: Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 30949009</p><p><b>display</b>: Enterococcus casseliflavus (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 53233007</p><p><b>display</b>: Enterococcus gallinarum (organism)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 703032005</p><p><b>display</b>: Enterococcus casseliflavus or Enterococcus gallinarum (finding)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 30949009</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 53233007</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 703032005</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1468",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1468"
+					}
+				],
+				"version": "1.0.0",
+				"name": "EnterococcusgallinarumorEcasseliflavusEflavescensOrganismorSubstanceinLabResults",
+				"title": "Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Enterococcus gallinarum or E. casseliflavus/E. flavescens (Organism or Substance in Lab Results)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "406575008"
+								}
+							],
+							"text": "Infection caused by vancomycin resistant enterococcus (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "30949009",
+									"display": "Enterococcus casseliflavus (organism)"
+								},
+								{
+									"code": "53233007",
+									"display": "Enterococcus gallinarum (organism)"
+								},
+								{
+									"code": "703032005",
+									"display": "Enterococcus casseliflavus or Enterococcus gallinarum (finding)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "30949009"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "53233007"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "703032005"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1439",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1439\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1439</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: RabiesSuspectedDisordersSNOMED</p><p><b>title</b>: Rabies [Suspected] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Rabies [Suspected] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><blockquote><p><b>concept</b></p><p><b>code</b>: 722545003</p><p><b>display</b>: Suspected rabies (situation)</p></blockquote><blockquote><p><b>concept</b></p><p><b>code</b>: 722546002</p><p><b>display</b>: Probable rabies (situation)</p></blockquote></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 722545003</p></blockquote><blockquote><p><b>contains</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><p><b>code</b>: 722546002</p></blockquote></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1439",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1439"
+					}
+				],
+				"version": "1.0.0",
+				"name": "RabiesSuspectedDisordersSNOMED",
+				"title": "Rabies [Suspected] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Rabies [Suspected] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "14168008"
+								}
+							],
+							"text": "Rabies (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "722545003",
+									"display": "Suspected rabies (situation)"
+								},
+								{
+									"code": "722546002",
+									"display": "Probable rabies (situation)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "722545003"
+						},
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "722546002"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1436",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1436\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1436</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: MeaslesSuspectedDisordersSNOMED</p><p><b>title</b>: Measles [Suspected] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Measles [Suspected] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><h3>Concepts</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Display</b></td></tr><tr><td>*</td><td>772152006</td><td>Measles suspected (situation)</td></tr></table></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><h3>Contains</h3><table class=\"grid\"><tr><td>-</td><td><b>System</b></td><td><b>Version</b></td><td><b>Code</b></td></tr><tr><td>*</td><td><a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></td><td>Provisional_2022-01-10</td><td>772152006</td></tr></table></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1436",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1436"
+					}
+				],
+				"version": "1.0.0",
+				"name": "MeaslesSuspectedDisordersSNOMED",
+				"title": "Measles [Suspected] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Measles [Suspected] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "14189004"
+								}
+							],
+							"text": "Measles (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "772152006",
+									"display": "Measles suspected (situation)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772152006"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1435",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1435\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1435</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: DiphtheriaSuspectedDisordersSNOMED</p><p><b>title</b>: Diphtheria [Suspected] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Diphtheria [Suspected] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><h3>Concepts</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Display</b></td></tr><tr><td>*</td><td>772150003</td><td>Diphtheria suspected (situation)</td></tr></table></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><h3>Contains</h3><table class=\"grid\"><tr><td>-</td><td><b>System</b></td><td><b>Version</b></td><td><b>Code</b></td></tr><tr><td>*</td><td><a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></td><td>Provisional_2022-01-10</td><td>772150003</td></tr></table></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1435",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1435"
+					}
+				],
+				"version": "1.0.0",
+				"name": "DiphtheriaSuspectedDisordersSNOMED",
+				"title": "Diphtheria [Suspected] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Diphtheria [Suspected] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "276197005"
+								}
+							],
+							"text": "Infection caused by Corynebacterium diphtheriae (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "772150003",
+									"display": "Diphtheria suspected (situation)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772150003"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1446",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1446\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1446</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: ViralHemorrhagicFeverSuspectedDisordersSNOMED</p><p><b>title</b>: Viral Hemorrhagic Fever [Suspected] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Viral Hemorrhagic Fever [Suspected] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><h3>Concepts</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Display</b></td></tr><tr><td>*</td><td>772158005</td><td>Viral hemorrhagic fever suspected (situation)</td></tr></table></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><h3>Contains</h3><table class=\"grid\"><tr><td>-</td><td><b>System</b></td><td><b>Version</b></td><td><b>Code</b></td></tr><tr><td>*</td><td><a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></td><td>Provisional_2022-01-10</td><td>772158005</td></tr></table></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1446",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1446"
+					}
+				],
+				"version": "1.0.0",
+				"name": "ViralHemorrhagicFeverSuspectedDisordersSNOMED",
+				"title": "Viral Hemorrhagic Fever [Suspected] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Viral Hemorrhagic Fever [Suspected] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "240523007"
+								}
+							],
+							"text": "Viral hemorrhagic fever (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "772158005",
+									"display": "Viral hemorrhagic fever suspected (situation)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772158005"
+						}
+					]
+				}
+			}
+		},
+		{
+			"fullUrl": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438",
+			"resource": {
+				"resourceType": "ValueSet",
+				"id": "2.16.840.1.113762.1.4.1146.1438",
+				"meta": {
+					"profile": [
+						"http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-triggering-valueset"
+					]
+				},
+				"text": {
+					"status": "extensions",
+					"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: ValueSet</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource ValueSet \"2.16.840.1.113762.1.4.1146.1438\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-us-ph-triggering-valueset.html\">US Public Health Triggering ValueSet</a></p></div><p><b>author</b>: CSTE Author: </p><p><b>steward</b>: CSTE Steward: </p><p><b>url</b>: <code>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438</code></p><p><b>identifier</b>: id: urn:oid:2.16.840.1.113762.1.4.1146.1438</p><p><b>version</b>: 1.0.0</p><p><b>name</b>: PoliomyelitisSuspectedDisordersSNOMED</p><p><b>title</b>: Poliomyelitis [Suspected] (Disorders) (SNOMED)</p><p><b>status</b>: active</p><p><b>experimental</b>: true</p><p><b>publisher</b>: eCR</p><p><b>description</b>: Poliomyelitis [Suspected] (Disorders) (SNOMED)</p><blockquote><p><b>compose</b></p><blockquote><p><b>include</b></p><p><b>system</b>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></p><p><b>version</b>: Provisional_2022-01-10</p><h3>Concepts</h3><table class=\"grid\"><tr><td>-</td><td><b>Code</b></td><td><b>Display</b></td></tr><tr><td>*</td><td>772155008</td><td>Acute poliomyelitis suspected (situation)</td></tr></table></blockquote></blockquote><blockquote><p><b>expansion</b></p><p><b>timestamp</b>: 2022-04-05 10:06:43-0400</p><h3>Contains</h3><table class=\"grid\"><tr><td>-</td><td><b>System</b></td><td><b>Version</b></td><td><b>Code</b></td></tr><tr><td>*</td><td><a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a></td><td>Provisional_2022-01-10</td><td>772155008</td></tr></table></blockquote></div>"
+				},
+				"extension": [
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-author",
+						"valueContactDetail": {
+							"name": "CSTE Author"
+						}
+					},
+					{
+						"url": "http://hl7.org/fhir/StructureDefinition/valueset-steward",
+						"valueContactDetail": {
+							"name": "CSTE Steward"
+						}
+					}
+				],
+				"url": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1438",
+				"identifier": [
+					{
+						"system": "urn:ietf:rfc:3986",
+						"value": "urn:oid:2.16.840.1.113762.1.4.1146.1438"
+					}
+				],
+				"version": "1.0.0",
+				"name": "PoliomyelitisSuspectedDisordersSNOMED",
+				"title": "Poliomyelitis [Suspected] (Disorders) (SNOMED)",
+				"status": "active",
+				"experimental": true,
+				"publisher": "eCR",
+				"description": "Poliomyelitis [Suspected] (Disorders) (SNOMED)",
+				"useContext": [
+					{
+						"code": {
+							"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+							"code": "focus"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://snomed.info/sct",
+									"code": "398102009"
+								}
+							],
+							"text": "Acute poliomyelitis (disorder)"
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "reporting"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "triggering"
+								}
+							]
+						}
+					},
+					{
+						"code": {
+							"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type",
+							"code": "priority"
+						},
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context",
+									"code": "routine"
+								}
+							]
+						}
+					}
+				],
+				"compose": {
+					"include": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"concept": [
+								{
+									"code": "772155008",
+									"display": "Acute poliomyelitis suspected (situation)"
+								}
+							]
+						}
+					]
+				},
+				"expansion": {
+					"timestamp": "2022-04-05T10:06:43-04:00",
+					"contains": [
+						{
+							"system": "http://snomed.info/sct",
+							"version": "Provisional_2022-01-10",
+							"code": "772155008"
+						}
+					]
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
Revert to old isGrouper logic for import operation.

This had to be done as we want grouper-type use context to be added to groupers during import, but if it wasn't present it was being treated as a leaf.