### PR TITLE
users should only be able to navigate from navlink, not whole row

### DIFF
--- a/vsm-app/components/EditManifestDetails/index.tsx
+++ b/vsm-app/components/EditManifestDetails/index.tsx
@@ -197,7 +197,6 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
           </Typography>
           <DT
             data={availableLeafValueSetCodeSystems}
-            highlightOnHover
             keyField={'version'}
             defaultSortAsc={false}
             defaultSortFieldId={3}
@@ -248,7 +247,6 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
                 wrap: true
               }
             ]}
-            theme="aphl"
             fixedHeader
             customStyles={customTableStyles('readonly')}
             className="detail-table"
@@ -331,7 +329,6 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
           <StyledLabel>Available Versions</StyledLabel>
           <DT
             data={filterSelectedVersions(availableVersions, currentSelectedData, selectedSystem) || []}
-            highlightOnHover
             progressComponent={<LoadingIndicator />}
             progressPending={pageLoading}
             defaultSortAsc={false}

--- a/vsm-app/components/GrouperOverviewTable.tsx
+++ b/vsm-app/components/GrouperOverviewTable.tsx
@@ -183,10 +183,6 @@ const GrouperOverviewTable = ({ grouperLibId, programStatus }: GrouperTable) => 
             }
           }
         }}
-        highlightOnHover={true}
-        onRowClicked={(row: fhir4.ValueSet) => {
-          router.push(`/programs/${programId}/valuesets/${row.id}`)
-        }}
         data={groups}
         pagination
         paginationPerPage={10}

--- a/vsm-app/components/ManifestDetailTable.tsx
+++ b/vsm-app/components/ManifestDetailTable.tsx
@@ -164,7 +164,6 @@ const ManifestDetailTable = ({ deleteFn, updateFn, data: manifestData, loading, 
         progressComponent={<LoadingIndicator />}
         progressPending={loading}
         columns={columns}
-        highlightOnHover
         customStyles={customTableStyles('readonly')}
         data={preppedData}
         pagination

--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -787,7 +787,6 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
           theme="aphl"
           pagination
           clearSelectedRows={toggleUpdateData}
-          highlightOnHover={true}
           fixedHeader // TODO: Should we remove? adds an additional scrollbar
           progressPending={blockChanges}
           progressComponent={<LoadingIndicator />}

--- a/vsm-app/components/Provisional/ProgramsTab.tsx
+++ b/vsm-app/components/Provisional/ProgramsTab.tsx
@@ -240,7 +240,7 @@ const ProgramsTab: NextPage = () => {
         wrap: true
       },
       {
-        name: 'Create New',
+        name: <p>Create New</p>,
         selector: (row: fhir4.Library) => row.id || '',
         sortable: true,
         wrap: true,
@@ -373,7 +373,6 @@ const ProgramsTab: NextPage = () => {
         onChangePage={handlePageChange}
         onChangeRowsPerPage={(newRowsPerPage, newPage) => setPagination({ ...pagination, page: newPage, countPerPage: newRowsPerPage })}
         fixedHeader
-        highlightOnHover={true}
         progressPending={!programs?.length}
         progressComponent={<LoadingIndicator />}
       />

--- a/vsm-app/components/TextLink.tsx
+++ b/vsm-app/components/TextLink.tsx
@@ -2,18 +2,21 @@ import Link from 'next/link'
 import styled from 'styled-components'
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 
+const LinkContainer = styled.div`
+display: flex;
+color: var(--theme-300);
+align-items: center;
+&:hover {
+  color: var(--theme-500);
+};
+`
+
 const StyledLink = styled(Link)`
-  color: var(--theme-300);
   width: 100%;
   text-align: left;
   border: none;
   background: none;
   padding: 0;
-`
-
-const LinkContainer = styled.div`
-  display: flex;
-  align-items: center;
 `
 
 interface TextLinkProps {

--- a/vsm-app/components/tables/themes.ts
+++ b/vsm-app/components/tables/themes.ts
@@ -19,9 +19,6 @@ createTheme(
     rows: {
       style: {
         cursor: 'pointer',
-      },
-      highlightOnHoverStyle: {
-        backgroundColor: '#DBF0F3'
       }
     }
   },


### PR DESCRIPTION
Not all the tables were handled in previous PR, also fixed some small styling things

Whole rows are not clickable when there is a navlink now, users must click the link

Preferable esp in cases where there are buttons in the row that do other things => reduces confusion