### PR TITLE
Fix navigation behavior

### DIFF
--- a/vsm-app/pages/provisional/valueset/index.tsx
+++ b/vsm-app/pages/provisional/valueset/index.tsx
@@ -383,8 +383,8 @@ const ProvisionalVSEdit = () => {
   }
 
   // set a default selected row on initial render via query params if exists
-  const defaultSelectedRows = useCallback((row) => {
-    const result = row.id && router?.query?.vsSelected && (row.id === router?.query?.vsSelected)
+  const defaultSelectedRows = useCallback((row: fhir4.ValueSet) => {
+    const result = Boolean(row.id && router?.query?.vsSelected && (row.id === router?.query?.vsSelected))
     if (result) {
       setShowVsForm(true)
       setProvisionalVsIdForUpdate(row.id)


### PR DESCRIPTION
When a user selects that they want to edit a particular provisional VS, that valueset should be selected in the table when the navigation is complete.

selected state is passed as a query param
![provisional_navigate](https://github.com/user-attachments/assets/02f7004e-34e0-4e95-94c5-659bedd90a7b)
