### PR TITLE
menu portal, not control, should have high zindex

### DIFF
--- a/vsm-app/components/styleOverrides/reactSelect.ts
+++ b/vsm-app/components/styleOverrides/reactSelect.ts
@@ -14,8 +14,10 @@ export const reactSelectOptionStyle = (props?: StyleOptions | undefined) => {
       ...styles,
       minWidth: props?.minWidth || 'inherit',
       maxWidth: props?.maxWidth || 'inherit',
-      zIndex: 9999
     }),
-    menuPortal: (styles: any) => ({ ...styles, zIndex: 9999 })
+    menuPortal: (styles: any) => ({
+      ...styles,
+      zIndex: 9999
+    })
   })
 }


### PR DESCRIPTION
Fixes a bug where controls were overlapping