### PR TITLE
should show version in table only if pinned, not at all times

### DIFF
--- a/vsm-app/components/ValueSetDetailsTables.tsx
+++ b/vsm-app/components/ValueSetDetailsTables.tsx
@@ -31,6 +31,7 @@ interface GrouperTableDetail {
   oid: string
   canonical: string
   version?: string
+  valueSetPinnedVersion?: string | undefined
 }
 
 interface ValueSetDetailsTablesProps {
@@ -104,12 +105,14 @@ const ValueSetDetailsTables = ({
   const router = useRouter()
 
   const leafDataForDisplay = (pData: any) => {
-    return pData?.map((i: DataItem) => ({
+    return pData?.map((i: DataItem) => {
+     return ({
       title: i?.valueSet?.title,
       oid: i?.canonical?.split('/ValueSet/')?.[1],
       canonical: i?.canonical,
-      version: i?.version
-    }))
+      version: i?.version,
+      valueSetPinnedVersion: i?.valueSetPinnedVersion
+    })})
   }
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -189,7 +192,7 @@ const ValueSetDetailsTables = ({
         selector: (row: GrouperTableDetail) => row?.canonical!,
         sortable: true,
         wrap: true,
-        cell: (row: GrouperTableDetail) => (row?.version ? `${row?.canonical}|${row?.version}` : `${row?.canonical}`)
+        cell: (row: GrouperTableDetail) => (row?.valueSetPinnedVersion ? `${row?.canonical}|${row?.valueSetPinnedVersion}` : `${row?.canonical}`)
       }
     ]
 

--- a/vsm-app/hooks/useGetProgramValueSetDetails.ts
+++ b/vsm-app/hooks/useGetProgramValueSetDetails.ts
@@ -32,6 +32,7 @@ export interface DataItem {
   publisher: string
   version: string
   valueSet: fhir4.ValueSet
+  valueSetPinnedVersion: string | undefined
   programStatus: fhir4.Library['status']
 }
 


### PR DESCRIPTION
We were previously always showing a version in a grouper valueset's leaf definitions, even if they weren't pinned

This PR only includes the pinned valueset version if it exists

Before (top row is unpinned, so should not show a version for that leaf):
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/647ab97f-cbad-4b8f-9639-826ffccfb9c7">

After:
<img width="983" alt="image" src="https://github.com/user-attachments/assets/538e675a-8967-4219-b32b-f1882fc8c73a">
