### PR TITLE
handle $expand operation when valueset is not pinned

### DIFF
--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -383,9 +383,14 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
         sortable: false,
         maxWidth: '350px',
         wrap: true,
-        cell: (row: TableRow) => (
-          <TextLink href={`/programs/${currentProgram?.id}/valuesets/${row?.valueSet?.id}`} linkText={row.title} forceReload={false} />
-        )
+        cell: (row: TableRow) => {
+          let href = `/programs/${currentProgram?.id}/valuesets/${row?.valueSet?.id}`
+          if (row.valueSetPinnedVersion) {
+            href += '?pinnedVersion=true'
+          }
+          return (
+          <TextLink href={href} linkText={row.title} forceReload={false} />
+        )}
       },
       {
         name: (

--- a/vsm-app/components/ValueSetDetailsTables.tsx
+++ b/vsm-app/components/ValueSetDetailsTables.tsx
@@ -130,7 +130,11 @@ const ValueSetDetailsTables = ({
       expansionParameters: getProgramManifestVersions(programAndGrouperInfo.program!)
     }
     try {
-      const updatedValueSet = await fetch(`/api/valueset/${currentValueSet.id}/expand`, {
+      let endpoint = `/api/valueset/${currentValueSet.id}/expand`
+      if (router.query.pinnedVersion) {
+        body.pinnedVersion = true
+      }
+      const updatedValueSet = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -177,13 +181,18 @@ const ValueSetDetailsTables = ({
         selector: (row: GrouperTableDetail) => row?.title!,
         sortable: true,
         wrap: true,
-        cell: (row: GrouperTableDetail) => (
-          <TextLink
-            href={`/programs/${programAndGrouperInfo?.program?.id}/valuesets/${row?.valuesetId}`}
-            linkText={row.title}
-            forceReload={true}
-          />
-        )
+        cell: (row: GrouperTableDetail) => {
+          let href = `/programs/${programAndGrouperInfo?.program?.id}/valuesets/${row?.valuesetId}`
+          if (!row.valueSetPinnedVersion) {
+            href += '?pinnedVersion=true'
+          }
+          return (
+            <TextLink
+              href={href}
+              linkText={row.title}
+              forceReload={true}
+            />
+        )}
       },
       {
         name: 'OID',

--- a/vsm-app/pages/api/valueset/[id]/expand.ts
+++ b/vsm-app/pages/api/valueset/[id]/expand.ts
@@ -9,12 +9,13 @@ export interface ExpandRequest extends NextApiRequest {
   body: {
     valueSetId?: string
     expansionParameters: { [key: string]: string[] }
+    pinnedVersion?: boolean
   }
 }
 
 // perhaps simplify the requests by using the data that's in the FE for the table?
 const expandValueSets = async (req: ExpandRequest, res: NextApiResponse) => {
-  const { valueSetId, expansionParameters } = req.body
+  const { valueSetId, expansionParameters, pinnedVersion } = req.body
   if (valueSetId == null) {
     logger.error('Invalid request, missing ValueSet ID.')
     return res.status(400).json({ error: 'Invalid request, missing ValueSet ID.' })
@@ -44,10 +45,10 @@ const expandValueSets = async (req: ExpandRequest, res: NextApiResponse) => {
         valueCanonical: valueCanonicalString.join(',')
       })
     }
-    console.log(codeSystemList)
-    // in this case expanding just one valueset
 
-    setParameterVsVersion(parameters, valueSet)
+    if (pinnedVersion) {
+      setParameterVsVersion(parameters, valueSet)
+    }
     const oid = extractOidFromUrl(valueSet.url!)
     const url = vsacFhirClient.baseUrl + `/ValueSet/${oid}/$expand`
     const fetchOptions = getExpandFetchOptions(parameters)

--- a/vsm-app/tests/api/valueset/expand.spec.ts
+++ b/vsm-app/tests/api/valueset/expand.spec.ts
@@ -31,7 +31,8 @@ describe('pages/api/valueset/[id]/expand', () => {
       expansionParameters: {
         'http://loinc.org': ['2.69']
       },
-      valueSetId: '4224'
+      valueSetId: '4224',
+      pinnedVersion: true
     }
     const { req, res } = createMocks<ExpandRequest, NextApiResponse>({
       method: 'POST',
@@ -55,8 +56,8 @@ describe('pages/api/valueset/[id]/expand', () => {
     })
     await handler(req, res)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    console.log(fetchMock.mock.calls[0][0])
     expect(fetchMock.mock.calls[0][0]).toContain('ValueSet/2.32.33.44.22.55/$expand')
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('POST')
 
     expect(fetchMock.mock.calls[0][1].body).toBe(
       JSON.stringify({
@@ -74,7 +75,8 @@ describe('pages/api/valueset/[id]/expand', () => {
       expansionParameters: {
         'http://snomed.info/sct': ['http://snomed.info/sct/731000124108/version/20240301']
       },
-      valueSetId: '4224'
+      valueSetId: '4224',
+      pinnedVersion: true
     }
     const { req, res } = createMocks<ExpandRequest, NextApiResponse>({
       method: 'POST',
@@ -98,8 +100,8 @@ describe('pages/api/valueset/[id]/expand', () => {
     })
     await handler(req, res)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    console.log(fetchMock.mock.calls[0][0])
     expect(fetchMock.mock.calls[0][0]).toContain('ValueSet/2.32.33.44.22.55/$expand')
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('POST')
 
     expect(fetchMock.mock.calls[0][1].body).toBe(
       JSON.stringify({
@@ -109,6 +111,40 @@ describe('pages/api/valueset/[id]/expand', () => {
         ]
       })
     )
+  })
+
+  test('should not include valueSetVersion for unpinned valueset', async () => {
+    const body: ExpandRequest['body'] = {
+      expansionParameters: {
+        'http://snomed.info/sct': ['http://snomed.info/sct/731000124108/version/20240301']
+      },
+      valueSetId: '4224',
+    }
+    const { req, res } = createMocks<ExpandRequest, NextApiResponse>({
+      method: 'POST',
+      body: body
+    })
+    fhirCdrClient.read = jest.fn().mockResolvedValue({
+      resourceType: 'ValueSet',
+      id: '4224',
+      url: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.32.33.44.22.55',
+      version: '07012018',
+      name: 'LL269-2',
+      title: 'LL269-2',
+      status: 'active',
+      compose: {
+        include: [
+          {
+            system: 'http://loinc.org'
+          }
+        ]
+      }
+    })
+    await handler(req, res)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('ValueSet/2.32.33.44.22.55/$expand')
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('GET')
+    expect(fetchMock.mock.calls[0][1].body).toBeUndefined()
   })
 
 


### PR DESCRIPTION
Conditionally adding in valuesetVersion dependent on if the vs expand operation is from a pinned version

