### PR TITLE
wording for expansion

### DIFF
--- a/vsm-app/components/ValueSetDetailsTables.tsx
+++ b/vsm-app/components/ValueSetDetailsTables.tsx
@@ -291,7 +291,7 @@ const ValueSetDetailsTables = ({
         <Tabs value={value} onChange={handleTabChange}>
           <Tab label="Definition" {...a11yProps(0)} />
           {!isVsmVset && <Tab label="Expansion" {...a11yProps(1)} />}
-          {value === 1 && isDraftProgram && (
+          {value === 1 && (
             <Box sx={{ ml: 'auto', mr: 3, display: 'flex' }}>
               {isDraftProgram && (
                 <Box sx={{ mt: 1, mr: 1 }}>


### PR DESCRIPTION
for draft:
<img width="969" alt="image" src="https://github.com/user-attachments/assets/99a96f67-6eb8-41c8-8bd7-0654c7a5c33d">

released is the same, but you lose the "warning" popover icon