### PR TITLE
Aphl 1121 fix msg for background program (leaf update from term server)

### DIFF
--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -351,7 +351,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
   const handleUpdateValueSets = async (groupsInProgram: fhir4.ValueSet[] = []) => {
     toast.info(
       <div style={{ paddingLeft: '10px' }}>
-        <p>Attempting to update all Value Sets with version 'latest' by fetching newest available data from terminology servers.</p>
+        <p>Attempting to update all Value Sets with version &lsquo;latest&rsquo; by fetching newest available data from terminology servers.</p>
         <p>This is a long running operation.</p>
         <p>Please wait for completion.</p>
         <LinearProgress color="secondary" />


### PR DESCRIPTION
This PR clarifies the messaging around Bulk Valueset update

_________________


@man0a the updateBulkValueSets funtion in update.ts fails with this error... I added a log to see it

Do you know if this just some sort of fetch timeout, or is this a legitimate error? If it's a timeout we might want to add comments to the code to warn about it, but I'm not sure how to tell

```
error 1: , MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20). Refer to "maxRetriesPerRequest" option for details.
    at Socket.<anonymous> (/Users/cknbrd/Documents/projects/aphl-vsm/vsm-app/node_modules/ioredis/built/redis/event_handler.js:175:37)
    at Object.onceWrapper (node:events:629:26)
    at Socket.emit (node:events:514:28)
    at TCP.<anonymous> (node:net:337:12)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)
{}
 PUT /api/valueset/update 500 in 233008ms
 GET /api/auth/session 200 in 11ms
[11:48:42.395] INFO (89716): Request: GET /api/valueset/update?jobId=undefined
 GET /api/valueset/update?jobId=undefined 500 in 420095ms
```