### PR TITLE
fix stateful error in code system edit flow

### DIFF
--- a/vsm-app/components/Provisional/ProvisionalEditForm.tsx
+++ b/vsm-app/components/Provisional/ProvisionalEditForm.tsx
@@ -188,6 +188,7 @@ const ExistingCodesTable = ({ codeSystem, isEditable, mutate }: { codeSystem?: f
           setItemToDelete(null)
         } else {
           mutate()
+          setOriginalCodeItemToEdit(null)
           setCodeUpdateLoading(false)
           toast.success(`Provisional Code '${itemToDelete?.code}' deleted`)
           setItemToDelete(null)


### PR DESCRIPTION
Very small fix to reset a state variable when users delete a code.
Preeti recorded in a bug ticket that a button was staying disabled after a successful delete, this fixes it