### PR TITLE
use full tag instead of just value in client

### DIFF
--- a/vsm-app/helpers/server/serverValueSetHelper.ts
+++ b/vsm-app/helpers/server/serverValueSetHelper.ts
@@ -138,7 +138,7 @@ export const fetchLeafValueSets = async ({
       if (version) {
         searchParameters.version = version
       } if (provisionalOnly) {
-        searchParameters._tag = 'vsm-provisional' 
+        searchParameters._tag = 'http://aphl.org/fhir/vsm/CodeSystem/vsm-workflow-codes|vsm-provisional'
       }
       return fhirCdrClient.search({
         resourceType: 'ValueSet',

--- a/vsm-app/pages/api/programs/provisional.ts
+++ b/vsm-app/pages/api/programs/provisional.ts
@@ -37,7 +37,7 @@ const getAllValueSetsReferencingProvisionalCS = async (): Promise<ProvisionalVsC
   const provisionalVS = await fhirCdrClient.search({
     resourceType: 'ValueSet',
     searchParams: {
-      _tag: 'vsm-provisional'
+      _tag: 'http://aphl.org/fhir/vsm/CodeSystem/vsm-workflow-codes|vsm-provisional'
     }
   })
 

--- a/vsm-app/pages/api/valueset/provisional/index.ts
+++ b/vsm-app/pages/api/valueset/provisional/index.ts
@@ -259,9 +259,8 @@ export const getProvisionals = async ({ resourceType, params = {} }: GetProvPara
   try {
 
     const searchParams = Object.assign({
-      _tag: 'vsm-provisional'
+      _tag: 'http://aphl.org/fhir/vsm/CodeSystem/vsm-workflow-codes|vsm-provisional'
     }, params) as SearchParams
-
 
     const provisionalBundle = await fhirCdrClient.search({
       resourceType,


### PR DESCRIPTION
Update to use full `<meta.tag system>|<meta.tag value>` when using tags to target FHIR resources 