### PR TITLE
ignore errors when provisional valueset is used

### DIFF
--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -118,8 +118,9 @@ const getTerminologySource = (valueSet: fhir4.ValueSet, errors: string[]): Termi
             url: terminologyExt?.valueUri
           }
         }
+      } else {
+        errors.push(`Value Set ${valueSet.id} has no matching Authoritative Source`)
       }
-      errors.push(`Value Set ${valueSet.id} has no matching Authoritative Source`)
     }
     return {
       value: val?.label || "",


### PR DESCRIPTION
I think this is a bug, it shouldn't send an error message when we are matching ourselves to the terminology source