### PR TITLE
fix bug with last expansion item via css

### DIFF
--- a/vsm-app/components/Provisional/ProgramsTab.tsx
+++ b/vsm-app/components/Provisional/ProgramsTab.tsx
@@ -568,6 +568,7 @@ const ProgramsTab: NextPage = () => {
       </div>
       <ErrorMessage error={error?.error || null} handleClose={() => setError({})} />
       <DT
+        className='programs-tab-table'
         key={refreshkey}
         data={programs}
         clearSelectedRows={toggledClearRows}

--- a/vsm-app/styles/globals.css
+++ b/vsm-app/styles/globals.css
@@ -436,3 +436,7 @@ button {
 [data-column-id='value-set-conditions'].rdt_TableCol .rdt_TableCol_Sortable {
   overflow: visible;
 }
+
+.programs-tab-table {
+  max-height: unset !important;
+}


### PR DESCRIPTION
When accordion items are expanded, this max-height was hiding data below the fold.
This removes the issue.
![expand](https://github.com/user-attachments/assets/6137df38-8185-4c0d-8a57-5b2147ad9ab8)
