### PR TITLE
increase default toast timeout from 3 to 7 seconds for non auto-close

### DIFF
--- a/vsm-app/pages/_app.tsx
+++ b/vsm-app/pages/_app.tsx
@@ -101,7 +101,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps }, emotionCache =
       <NavContextProvider>
         <ToastContainer
           position="top-right"
-          autoClose={3000}
+          autoClose={7000}
           hideProgressBar
           newestOnTop
           closeOnClick


### PR DESCRIPTION
Increase toast timeout from ToastContainer component

For auto-close toasts, the time the message will stay up has been increased from 3 to 7 seconds. 10 seconds felt too long

