### PR TITLE
Update Library Import test to validate PlanDefinition isOwned extension is present

### DIFF
--- a/ecr/src/test/java/org/opencds/cqf/ruler/TransformLibraryTest.java
+++ b/ecr/src/test/java/org/opencds/cqf/ruler/TransformLibraryTest.java
@@ -82,6 +82,16 @@ public class TransformLibraryTest extends RestIntegrationTest {
 			.collect(Collectors.toList());
 		assertTrue(!ra.isEmpty());
 
+		List<RelatedArtifact> pds = updatedRootLibrary
+			.getRelatedArtifact()
+			.stream()
+			.filter(i -> i.getType().equals(RelatedArtifact.RelatedArtifactType.COMPOSEDOF))
+			.filter(i -> i.getResourceElement().asStringValue().equals("http://hl7.org/fhir/us/ecr/PlanDefinition/plandefinition-ersd-instance-example|0.1"))
+			.collect(Collectors.toList());
+		assertEquals(1, pds.size());
+		assertTrue(pds.get(0).hasExtension("http://hl7.org/fhir/StructureDefinition/artifact-isOwned"));
+
+
 		CodeableConcept conditionCodeableConcept = (CodeableConcept) ra.get(0).getExtension().get(0).getValue();
 		assertEquals(conditionCodeableConcept.getText(), "Infection caused by Acanthamoeba (disorder)");
 


### PR DESCRIPTION
https://alphora.atlassian.net/browse/APHL-1263

It was reported that the $ersd-v2-import operation was resulting in the related artifact-isOwned extension for PlanDefinitions being missing.

It has been observed as working in Dev/QA, was likely an issue with bad data. Updating the Library Import test to add some validation to ensure this outcome is preserved.