### PR TITLE
Dependency upgrades

### DIFF
--- a/vsm-app/package-lock.json
+++ b/vsm-app/package-lock.json
@@ -25,7 +25,7 @@
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "next": "^14.2.15",
-        "next-auth": "4.24.7",
+        "next-auth": "4.24.11",
         "normalize.css": "^8.0.1",
         "pino": "^8.11.0",
         "pino-pretty": "^10.0.0",
@@ -4603,9 +4603,10 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9945,13 +9946,14 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
-      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.0",
         "jose": "^4.15.5",
         "oauth": "^0.9.15",
         "openid-client": "^5.4.0",
@@ -9960,12 +9962,16 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "next": "^12.2.5 || ^13 || ^14",
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18",
-        "react-dom": "^17.0.2 || ^18"
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
         "nodemailer": {
           "optional": true
         }
@@ -16143,9 +16149,9 @@
       }
     },
     "cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -20222,13 +20228,13 @@
       }
     },
     "next-auth": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
-      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.0",
         "jose": "^4.15.5",
         "oauth": "^0.9.15",
         "openid-client": "^5.4.0",

--- a/vsm-app/package.json
+++ b/vsm-app/package.json
@@ -31,7 +31,7 @@
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "next": "^14.2.15",
-    "next-auth": "4.24.7",
+    "next-auth": "4.24.11",
     "normalize.css": "^8.0.1",
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0",


### PR DESCRIPTION
2 dependency upgrades
Upgraded next-auth from 4.24.7  to 4.24.11... didn't seem to cause any problems locally


```
cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
fix available via 'npm audit fix --force'
Will install next-auth@4.24.11, which is outside the stated dependency range
node_modules/cookie
  next-auth  <=0.0.0-pr.11562.ed0fce23 || 4.0.0-beta.1 - 4.0.0-beta.7 || 4.0.1 - 4.24.8
  Depends on vulnerable versions of cookie
  node_modules/next-auth

nanoid  <3.3.8
Severity: moderate
Predictable results in nanoid generation when given non-integer values - https://github.com/advisories/GHSA-mwcw-c2x4-8c55
fix available via 'npm audit fix'
node_modules/nanoid
```