### PR TITLE
fix timezone issue in rendering dates

### DIFF
--- a/vsm-app/components/DateInput.tsx
+++ b/vsm-app/components/DateInput.tsx
@@ -5,6 +5,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { IconButton, Box } from '@mui/material'
 import CancelIcon from '@mui/icons-material/Cancel'
 import dayjs from 'dayjs'
+
 interface DateInputProps {
   readonly: boolean
   defaultValue?: string

--- a/vsm-app/helpers/formatDates.ts
+++ b/vsm-app/helpers/formatDates.ts
@@ -26,9 +26,9 @@ const formatDateForTable = (date: string | any, format: string): string => {
     }
 
     try {
-      if (format?.toLowerCase() === 'm/d/yyyy') {
+      if (format?.toLowerCase() === 'm/d/yyyy' || format?.toLowerCase() === 'yyyy/mm/dd') {
         const dateItem = new Date(date)
-        const formattedDate = new Intl.DateTimeFormat('en-US').format(dateItem)
+        const formattedDate = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' }).format(dateItem)
         return formattedDate
       }
       return date
@@ -40,10 +40,9 @@ const formatDateForTable = (date: string | any, format: string): string => {
   } else if (typeof date === 'number') {
     try {
       const dateItem = new Date(date)
-      const formattedDate = new Intl.DateTimeFormat('en-US').format(dateItem)
+      const formattedDate = new Intl.DateTimeFormat('en-US', { timeZone: 'UTC' }).format(dateItem)
       return formattedDate
     } catch (e) {
-      console.log('error formatting date: ', e)
       return ''
     }
   }


### PR DESCRIPTION
There was a timezone issue with the effectiveStart field on the program comparison page-- had to set it to UTC to match what we see on the programs page