### PR TITLE
refactor jobs to pull vsac credentials instead of encoded env

### DIFF
--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -2,7 +2,6 @@ import ExcelJS from 'exceljs'
 import FhirClient from '@/backend/clients/FhirClient'
 import { getVsSteward, getVsAuthor, getOid } from '@/helpers/valueSetHelpers'
 import { startCase, times, uniq } from 'lodash'
-import { addTerminologyEndpointToParameters } from './fhirResourceHelper'
 import { Agent, fetch as f } from 'undici'
 interface CollectedChange extends ChangeValue {
   keyName: string
@@ -97,32 +96,9 @@ const autosortTable = (table: ExcelJS.Table, tableRows: ExcelJS.Rows, sheet: Exc
   })
 }
 
-const changeLogDiffOperation = async (sourceId: string, targetId: string) => {
-  const parameters: fhir4.Parameters = {
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'source',
-        valueString: `Library/${sourceId}`
-      },
-      {
-        name: 'target',
-        valueString: `Library/${targetId}`
-      },
-      {
-        name: 'compareComputable',
-        valueBoolean: true
-      },
-      {
-        name: 'compareExecutable',
-        valueBoolean: true
-      }
-    ]
-  }
-  const input = JSON.stringify(addTerminologyEndpointToParameters(parameters))
-
+const changeLogDiffOperation = async (sourceId: string, targetId: string, input: fhir4.Parameters) => {
   const changeJson = await f(`${FhirClient.getInstance().baseUrl}/$create-changelog`, {
-    body: input,
+    body: JSON.stringify(input),
     method: 'POST',
     dispatcher: new Agent({
       connectTimeout: 24 * 60 * 60 * 1000,

--- a/vsm-app/helpers/fhirResourceHelper.ts
+++ b/vsm-app/helpers/fhirResourceHelper.ts
@@ -1,3 +1,4 @@
+import { tsCredentialService } from '@/backend/services/TsCredentialService'
 import { cloneDeep } from 'lodash'
 
 type FhirResource = {
@@ -25,13 +26,21 @@ const setExtension = (resource: FhirResource, url: string, valueString: string) 
   return clonedResource
 }
 
-const addTerminologyEndpointToParameters = (parameters: fhir4.Parameters, address?: string): fhir4.Parameters => {
+type AddTerminologyEndpointToParameters = {
+  parameters: fhir4.Parameters;
+  address?: string;
+  userId: string;
+}
+
+const addTerminologyEndpointToParameters = async ({parameters, address, userId }: AddTerminologyEndpointToParameters): Promise<fhir4.Parameters> => {
+  const vsCreds = await tsCredentialService.getVsacCredentials(userId)
+  
   const updatedParameters = structuredClone(parameters)
   const endpointWithVsacCredentials: fhir4.Endpoint = {
     resourceType: 'Endpoint',
     extension: [
-      { url: 'vsacUsername', valueString: process.env.VSAC_USERNAME },
-      { url: 'apiKey', valueString: process.env.VSAC_API_KEY }
+      { url: 'vsacUsername', valueString: vsCreds.username },
+      { url: 'apiKey', valueString: vsCreds.password }
     ],
     address: address || process.env.NEXT_PUBLIC_VSAC_BASE_URL || '',
     connectionType: { system: 'http://hl7.org/fhir/ValueSet/endpoint-connection-type', code: 'hl7-fhir-rest' },

--- a/vsm-app/pages/api/programs/[id]/manifest.ts
+++ b/vsm-app/pages/api/programs/[id]/manifest.ts
@@ -9,6 +9,7 @@ import { uniqBy } from 'lodash'
 import { addTerminologyEndpointToParameters } from '@/helpers/fhirResourceHelper'
 import { Agent, fetch as f } from 'undici'
 import { is } from '@/helpers/is'
+import { VSMSession } from '@/helpers/rolesHelper'
 
 const getManifestVersions = async (req: NextApiRequest, res: NextApiResponse) => {
   terminologyClient.setClient('vsac')
@@ -63,8 +64,8 @@ const getManifestVersions = async (req: NextApiRequest, res: NextApiResponse) =>
   }
 }
 
-const collectCodeSystemsFromLeafValuesets = async (programId: string) => {
-  const parameters = addTerminologyEndpointToParameters({ resourceType: 'Parameters' } as fhir4.Parameters)
+const collectCodeSystemsFromLeafValuesets = async (programId: string, userId: string) => {
+  const parameters = await addTerminologyEndpointToParameters({parameters: { resourceType: 'Parameters' } as fhir4.Parameters, userId})
 
   const response = await f(`${FhirClient.getInstance().baseUrl}/Library/${programId}/$ecr.package`, {
     body: JSON.stringify(parameters),
@@ -147,13 +148,13 @@ const collectCodeSystemsFromLeafValuesets = async (programId: string) => {
     .filter((i: any) => i)
 }
 
-const getAvailableLatestVersionsFromLeafValueSets = async (req: NextApiRequest, res: NextApiResponse) => {
+const getAvailableLatestVersionsFromLeafValueSets = async (req: NextApiRequest, res: NextApiResponse, session: VSMSession ) => {
   try {
     if (req.query.leafValueSets) {
       const programId = req.query.id as string
 
       // Check all leaf ValueSets and collect their CodeSystem's
-      const list = await collectCodeSystemsFromLeafValuesets(programId)
+      const list = await collectCodeSystemsFromLeafValuesets(programId, session.user.id)
       return res.status(200).json(list)
     } else {
       terminologyClient.setClient('vsac')

--- a/vsm-app/pages/api/programs/[id]/release.ts
+++ b/vsm-app/pages/api/programs/[id]/release.ts
@@ -12,11 +12,12 @@ import {
 } from '@/helpers/libraryHelpers'
 import { ReleasePayload } from '@/components/modals/ReleaseModal'
 import { addTerminologyEndpointToParameters } from '@/helpers/fhirResourceHelper'
+import { VSMSession } from '@/helpers/rolesHelper'
 export interface ReleaseRequest extends NextApiRequest {
   body: ReleasePayload
 }
 // this only gets the program library
-const release = async (req: ReleaseRequest, res: NextApiResponse): Promise<any> => {
+const release = async (req: ReleaseRequest, res: NextApiResponse, session: VSMSession): Promise<any> => {
   const { releaseAsVersion, programId, releaseDescription = '', releaseLabel = '', effectiveStartDate, latestFromTxServer } = req.body
   let program: fhir4.Library | undefined
   try {
@@ -57,22 +58,25 @@ const release = async (req: ReleaseRequest, res: NextApiResponse): Promise<any> 
     program.version = releaseAsVersion
   }
 
-  const releasePayload = addTerminologyEndpointToParameters({
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'version',
-        valueString: removeDraftFromVersionString(program?.version!)
-      },
-      {
-        name: 'versionBehavior',
-        valueCode: 'force'
-      },
-      {
-        name: 'latestFromTxServer',
-        valueBoolean: latestFromTxServer
-      }
-    ]
+  const releasePayload = await addTerminologyEndpointToParameters({
+    parameters: {
+      resourceType: 'Parameters',
+      parameter: [
+        {
+          name: 'version',
+          valueString: removeDraftFromVersionString(program?.version!)
+        },
+        {
+          name: 'versionBehavior',
+          valueCode: 'force'
+        },
+        {
+          name: 'latestFromTxServer',
+          valueBoolean: latestFromTxServer
+        }
+      ]
+    },
+    userId: session.user.id
   })
 
   await FhirClient.getInstance().operation({

--- a/vsm-app/tests/api/programs/[id]/release.spec.ts
+++ b/vsm-app/tests/api/programs/[id]/release.spec.ts
@@ -16,6 +16,9 @@ jest.mock('next-auth/next', () => ({
   }))
 }))
 jest.mock('fhir-kit-client')
+jest.mock('../../../../helpers/fhirResourceHelper', () => ({
+  addTerminologyEndpointToParameters: jest.fn()
+}))
 
 describe('/api/programs/[id]/release', () => {
   test('POST /api/programs/[id]/release, releases a program', async () => {
@@ -27,6 +30,41 @@ describe('/api/programs/[id]/release', () => {
       programId: 'SpecificationLibrary',
       latestFromTxServer: false
     }
+
+    const input = {
+      resourceType: 'Parameters',
+      parameter: [
+        {
+          name: 'version',
+          valueString: '2.2.2'
+        },
+        {
+          name: 'versionBehavior',
+          valueCode: 'force'
+        },
+        {
+          name: 'latestFromTxServer',
+          valueBoolean: false
+        },
+        {
+          name: 'terminologyEndpoint',
+          resource: {
+            resourceType: 'Endpoint',
+            extension: [
+              { url: 'vsacUsername', valueString: 'test' },
+              { url: 'apiKey', valueString: 'password' }
+            ],
+            address: 'https://cts.nlm.nih.gov/fhir',
+            connectionType: { system: 'http://hl7.org/fhir/ValueSet/endpoint-connection-type', code: 'hl7-fhir-rest' },
+            status: 'active',
+            payloadType: [{ coding: [{ system: 'http://hl7.org/fhir/ValueSet/endpoint-payload-type', code: 'any' }] }]
+          }
+        }
+      ]
+    }
+
+    addTerminologyEndpointToParameters.mockResolvedValue(input)
+
     const { req, res } = createMocks<ReleaseRequest, NextApiResponse>({
       method: 'POST',
       query: {
@@ -72,29 +110,15 @@ describe('/api/programs/[id]/release', () => {
       }
     })
 
+
+
     expect(FhirClient.getInstance().operation).toHaveBeenCalledTimes(1)
     expect(FhirClient.getInstance().operation).toHaveBeenCalledWith({
       name: '$release',
       resourceType: 'Library',
       id: 'SpecificationLibrary',
       method: 'POST',
-      input: addTerminologyEndpointToParameters({
-        resourceType: 'Parameters',
-        parameter: [
-          {
-            name: 'version',
-            valueString: "2.2.2"
-          },
-          {
-            name: 'versionBehavior',
-            valueCode: 'force'
-          },
-          {
-            name: 'latestFromTxServer',
-            valueBoolean: false
-          }
-        ]
-      })
+      input: input
     })
 
     expect(res._getStatusCode()).toBe(200)
@@ -142,7 +166,7 @@ describe('/api/programs/[id]/release', () => {
       releaseDescription: 'Release Description',
       releaseLabel: 'ReleaseV2.2.2',
       effectiveStartDate: '2022-01-01',
-      programId: "SpecificationLibrary",
+      programId: 'SpecificationLibrary',
       latestFromTxServer: false
     }
     const { req, res } = createMocks<ReleaseRequest, NextApiResponse>({

--- a/vsm-app/worker/ChangeLogQueue.ts
+++ b/vsm-app/worker/ChangeLogQueue.ts
@@ -1,11 +1,10 @@
 import Cache from '@/cache'
 import { DEFAULT_JOB_CONFIG, JOB_EXPIRATION, QUEUE_REDIS_URL } from '@/config'
 import { changeLogDiffOperation } from '@/helpers/exportExcelHelper'
-
 import { JOB_STATUS, JOB_TYPE } from '@/constants'
 import Queue from 'bull'
 import Logger from '@/helpers/server/logger'
-import { ExportJobMetadata } from '@/types/jobTypes'
+import { addTerminologyEndpointToParameters } from '@/helpers/fhirResourceHelper'
 
 const ChangeLogQueue = new Queue('changeLogCompare', QUEUE_REDIS_URL)
 
@@ -35,7 +34,29 @@ ChangeLogQueue.process(async function (job: any, done) {
   const { baseProgramId, targetProgramId, userId } = job.data
   const cacheKey = `user:${userId}:job:${job.id}`
 
-  const changelogData = await changeLogDiffOperation(baseProgramId, targetProgramId) as fhir4.OperationOutcome | fhir4.Binary
+  const parameters: fhir4.Parameters = {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'source',
+        valueString: `Library/${baseProgramId}`
+      },
+      {
+        name: 'target',
+        valueString: `Library/${targetProgramId}`
+      },
+      {
+        name: 'compareComputable',
+        valueBoolean: true
+      },
+      {
+        name: 'compareExecutable',
+        valueBoolean: true
+      }
+    ]
+  }
+  const input = await addTerminologyEndpointToParameters({parameters, userId})
+  const changelogData = await changeLogDiffOperation(baseProgramId, targetProgramId, input) as fhir4.OperationOutcome | fhir4.Binary
   const cache = await Cache.getInstance()
 
   if (changelogData?.resourceType === 'OperationOutcome') {

--- a/vsm-app/worker/PackageQueue.ts
+++ b/vsm-app/worker/PackageQueue.ts
@@ -147,7 +147,7 @@ PackageQueue.process(async function (job: any, done) {
   Logger.getLogger().info('Begin Export Operation Job')
   const { data, programId, planDefinition, targetVersion, userId } = job.data
   job.progress(1)
-  const parameters = addTerminologyEndpointToParameters(data?.parameters)
+  const parameters = await addTerminologyEndpointToParameters({parameters: data?.parameters, userId})
   const userDesiredFormat = data?.json ? 'json' : 'xml'
   const useV1 = !data?.useV2
   const cache = await Cache.getInstance()


### PR DESCRIPTION
had to move things around so we pull from the user creds for vsac credentials