### PR TITLE
Override backoff & retry default settings to increase attempts and delay

### DIFF
--- a/ecr/src/main/java/org/opencds/cqf/ruler/CaseReportingConfig.java
+++ b/ecr/src/main/java/org/opencds/cqf/ruler/CaseReportingConfig.java
@@ -4,6 +4,8 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.cr.common.IRepositoryFactory;
 import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
 import org.opencds.cqf.external.annotations.OnR4Condition;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClient;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClientSettings;
 import org.opencds.cqf.ruler.r4.CaseReportingOperationProvider;
 import org.opencds.cqf.ruler.r4.KnowledgeArtifactProcessor;
 import org.opencds.cqf.ruler.r4.MeasureDataProcessProvider;
@@ -57,5 +59,19 @@ public class CaseReportingConfig {
 	@Bean
 	CaseReportingProviderLoader caseReportingProviderLoader(FhirContext theFhirContext, ResourceProviderFactory theResourceProviderFactory) {
 		return new CaseReportingProviderLoader(theFhirContext, theResourceProviderFactory);
+	}
+
+	@Bean
+	TerminologyServerClientSettings terminologyServerClientSettings() {
+		return new TerminologyServerClientSettings()
+				.setRetryIntervalMillis(2000)
+				.setMaxRetryCount(5)
+				.setTimeoutSeconds(30);
+	}
+
+	@Bean
+	@Conditional(OnR4Condition.class)
+	TerminologyServerClient terminologyServerClient(TerminologyServerClientSettings terminologyServerClientSettings) {
+		return new TerminologyServerClient(FhirContext.forR4(), terminologyServerClientSettings);
 	}
 }

--- a/ecr/src/main/java/org/opencds/cqf/ruler/r4/CaseReportingOperationProvider.java
+++ b/ecr/src/main/java/org/opencds/cqf/ruler/r4/CaseReportingOperationProvider.java
@@ -42,6 +42,7 @@ import org.opencds.cqf.fhir.utility.Canonicals;
 import org.opencds.cqf.fhir.utility.SearchHelper;
 import org.opencds.cqf.fhir.utility.adapter.IKnowledgeArtifactAdapter;
 import org.opencds.cqf.fhir.utility.adapter.IAdapterFactory;
+import org.opencds.cqf.fhir.utility.client.TerminologyServerClient;
 import org.opencds.cqf.ruler.IBaseSerializer;
 import org.opencds.cqf.ruler.ValueSetCache.FhirRedisService;
 import org.opencds.cqf.ruler.ValueSetCache.ValueSetExpansionCache;
@@ -71,6 +72,8 @@ public class CaseReportingOperationProvider {
 	@Autowired
 	private DaoRegistry daoRegistry;
 
+	@Autowired
+	private TerminologyServerClient terminologyServerClient;
 
 	@Autowired
 	private FhirRedisService fhirRedisService;
@@ -421,9 +424,9 @@ public class CaseReportingOperationProvider {
 		PackageVisitor visitor;
 		if (fhirRedisService.isConnected()) {
 			var expansionCache = new ValueSetExpansionCache(fhirRedisService, FhirVersionEnum.R4);
-			visitor = new PackageVisitor(repository, null, expansionCache);
+			visitor = new PackageVisitor(repository, terminologyServerClient, expansionCache);
 		} else {
-			visitor = new PackageVisitor(repository);
+			visitor = new PackageVisitor(repository, terminologyServerClient);
 			log.warn("Redis service not found, running package without expansion cache");
 		}
 		var retval = (Bundle) adapter.accept(visitor, params);


### PR DESCRIPTION
By creating a TerminologyServerClient Bean which uses custom settings, and passing this into the PackageVisitor we can overrride the Default Retry & Backoff settings. 