### PR TITLE
in operator causes typerror if user.attributes not an obj

### DIFF
--- a/vsm-app/helpers/server/ApiTokenHandler.ts
+++ b/vsm-app/helpers/server/ApiTokenHandler.ts
@@ -39,8 +39,9 @@ class APITokenHandler {
   public async getBasicAuthCreds(userId: string, serverId: string) {
     await this.renewKeyCloakToken()
     const user = await this.retrieveStoredAttributes(userId)
-    if (serverId in user.attributes) {
-      const encryptedCreds = user.attributes[serverId][0]
+    const userAttributes = user?.attributes || {}
+    if (serverId in userAttributes) {
+      const encryptedCreds = userAttributes?.[serverId]?.[0]
       const userIV = await this.getUserIV(user)
       const decryptedCreds = this.decryptData(encryptedCreds, userIV)
       const base64Data = JSON.parse(decryptedCreds).value


### PR DESCRIPTION
When the app initially loads there is a typeError in the logs because you can't use the `in` operator on undefined