### PR TITLE
Hide Grouper Delete action

### DIFF
--- a/vsm-app/components/GrouperOverviewTable.tsx
+++ b/vsm-app/components/GrouperOverviewTable.tsx
@@ -151,7 +151,7 @@ const GrouperOverviewTable = ({ grouperLibId, program }: GrouperTable) => {
         sortable: true,
         wrap: true,
         maxWidth: '150px'
-      },
+      }/*,
       {
         name: 'Remove Group',
         maxWidth: '150px',
@@ -173,7 +173,7 @@ const GrouperOverviewTable = ({ grouperLibId, program }: GrouperTable) => {
             </ButtonContainer>
           )
         }
-      }
+      }*/
     ]
 
     return fields


### PR DESCRIPTION
Grouper Delete is currently failing, since $artifact-diff is invoked to ensure referential integrity is maintained - but the operation has not yet been migrated.