### PR TITLE
Bump Node Version in dockerfile and update vulnerabilities

### DIFF
--- a/vsm-app/Dockerfile
+++ b/vsm-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.18.1-alpine AS builder
+FROM node:24.14.0-alpine AS builder
 
 # Placeholder for build, will be replaced by actual runtime env vars
 ENV FHIR_CDR_URL="http://localhost:8082"
@@ -28,7 +28,12 @@ COPY ./ /opt/app
 RUN npm run build
 RUN npm prune --omit=dev
 
-FROM node:20.18.1-slim
+FROM node:24.14.0-slim
+
+RUN apt-get update && \
+	apt-get dist-upgrade -y && \
+	apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
Bump node images from 20.18.1 to 24.14.0 (LTS) and update any vulnerable dependencies.