### PR TITLE
Remove resourceType field from batch request entries to resolve warnings

### DIFF
--- a/vsm-app/helpers/server/expandUtils.ts
+++ b/vsm-app/helpers/server/expandUtils.ts
@@ -74,7 +74,6 @@ const getSpecifiedGroupers = async (groupersToSearch: string[], fhirCdrClient: F
     return {
       request: {
         method: 'GET',
-        resourceType: 'ValueSet',
         // why doesn't _elements work here?
         url: `ValueSet?_id=${grouperId}&_elements=id`
       }
@@ -202,7 +201,6 @@ const findMatchingVsetUrls = async ({
       return {
         request: {
           method: 'GET',
-          resourceType: 'ValueSet',
           url: searchUrl
         }
       }

--- a/vsm-app/helpers/server/serverValueSetHelper.ts
+++ b/vsm-app/helpers/server/serverValueSetHelper.ts
@@ -181,7 +181,6 @@ export const fetchLeafValueSets = async ({
     }
 
     return {
-      resourceType: 'ValueSet',
       request: {
         method: 'GET',
         url: `ValueSet${objectToQueryParams(searchParameters)}`

--- a/vsm-app/worker/VSDownloadQueue.ts
+++ b/vsm-app/worker/VSDownloadQueue.ts
@@ -17,7 +17,6 @@ VSDownloadQueue.process(async function (job: any, done) {
     return {
       request: {
         method: 'GET',
-        resourceType: 'ValueSet',
         url: `ValueSet?url=${url}&_elements=id`
       }
     }


### PR DESCRIPTION
Inclusion of resourceType in these batch request entries was resulting in the following warning being logged for each entry in the request, clogging up the logs.

"Unknown element resourceType found while parsing" 