### PR TITLE
Fix bug where we couldn't pin added VS's to the most recent version

### DIFF
--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -528,7 +528,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
                   onChange={async (evt) => {
                     if (evt?.value === 'latest' && row?.version === '[Undefined]') {
                       return
-                    } else if (row?.version !== evt?.value) {
+                    } else if (row?.version !== evt?.value || !row?.valueSetPinnedVersion) {
                       await handleVersionUpdate(evt, row)
                     }
                   }}


### PR DESCRIPTION
When we add a VS and try to pin the most recent version, the row version matched the selected version so the pinning was not performed.

This change ensures that whenever the 'valueSetPinnedVersion' is not defined, we pin the provided version. 