### PR TITLE
fixes cloning a non-released program

### DIFF
--- a/vsm-app/pages/api/programs/clone.ts
+++ b/vsm-app/pages/api/programs/clone.ts
@@ -33,7 +33,7 @@ const cloneProgram = async (req: NextApiRequest, res: NextApiResponse<DraftAPIRe
 
   const { programId, latestProgramVersion } = req.body
 
-  if (!latestProgramVersion || !programId) {
+  if (!programId) {
     return res.status(400).json({ error: 'Missing required parameters' })
   }
 


### PR DESCRIPTION
fixes #634 

The required-parameters guard in the clone API route incorrectly required
latestProgramVersion in addition to programId. latestProgramVersion is not always
available (e.g. for programs without a prior release), so the guard was updated to only
require programId.