### PR TITLE
fixes delete referential integrity error

### DIFF
--- a/vsm-app/pages/api/programs/[id]/delete.ts
+++ b/vsm-app/pages/api/programs/[id]/delete.ts
@@ -5,16 +5,25 @@ import { logSimpleError } from '@/helpers/server/simpleHapiError'
 
 const deleteProgram = async (req: NextApiRequest, res: NextApiResponse<{ message: string } | { error: string }>): Promise<void> => {
   const body = req.body
+  const programId = req.query.id as string
   try {
+    // Delete associated ArtifactAssessment (approval) records first to avoid referential integrity errors
+    const asstSearchResult = await FhirClient.getInstance().search({
+      resourceType: 'Basic',
+      searchParams: { artifact: programId }
+    }) as fhir4.Bundle
+    const assessmentIds = (asstSearchResult?.entry?.map((e) => e?.resource?.id).filter(Boolean) ?? []) as string[]
+    await Promise.all(assessmentIds.map((id) => FhirClient.getInstance().delete({ resourceType: 'Basic', id })))
+
     await FhirClient.getInstance().operation({
       name: '$delete',
       resourceType: 'Library',
-      id: req.query.id as string,
+      id: programId,
       method: 'POST',
       input: body
     })
 
-    res.status(200).send({ message: `Program with id ${req.query.id} deleted` })
+    res.status(200).send({ message: `Program with id ${programId} deleted` })
   } catch (error: any) {
     logSimpleError(error)
     const diagnostics = error?.response?.data?.issue?.[0]?.diagnostics


### PR DESCRIPTION
fixes #635 

Program deletion failed with a referential integrity error when the program had associated
ArtifactAssessment records (stored as Basic resources). The delete handler now queries
for and deletes all linked Basic records before issuing the $delete operation on the
Library. A null-safety fix was also applied: entry is undefined on empty FHIR search
results, so assessmentIds now defaults to an empty array via nullish coalescing (?? []).