### PR TITLE
fixes Edit Metadata incorrect Save button state

### DIFF
--- a/vsm-app/components/ProgramMetadata/index.tsx
+++ b/vsm-app/components/ProgramMetadata/index.tsx
@@ -58,7 +58,7 @@ const ProgramMetadata = ({ handleSubmit, program, editable = true }: ProgramEdit
   }
 
   useEffect(() => {
-    if(isExperimental !== program.experimental) {
+    if(isExperimental !== Boolean(program.experimental)) {
       setFormTouched(true)
     }
   }, [isExperimental])


### PR DESCRIPTION
fixes #636 

The Edit Metadata form incorrectly marked itself as "touched" (dirty) when
program.experimental was undefined, because a direct comparison of undefined !== false evaluates to true. The comparison was updated to use Boolean(program.experimental)
so undefined and false are treated as equivalent.