### PR TITLE
fixes 500 error with terminology server creds

### DIFF
--- a/vsm-app/pages/api/programs/[id]/manifest.ts
+++ b/vsm-app/pages/api/programs/[id]/manifest.ts
@@ -14,8 +14,8 @@ import { tsCredentialService } from '@/backend/services/TsCredentialService'
 
 const getManifestVersions = async (req: NextApiRequest, res: NextApiResponse, session: VSMSession) => {
   const userId = session.user.id
-  const vsacFhirClient = await TerminologyFhirClient.getClient(userId)
   try {
+    const vsacFhirClient = await TerminologyFhirClient.getClient(userId)
     if (req.query.url) {
       const results = await vsacFhirClient?.search({
         resourceType: 'CodeSystem',


### PR DESCRIPTION
fixes #637 

TerminologyFhirClient.getClient() was called outside the try/catch block, so any
error it threw (e.g. missing credentials) would produce an unhandled 500 response. The
call was moved inside the try block so errors are caught and handled consistently.