### PR TITLE
fixes release job hanging issue

### DIFF
--- a/vsm-app/components/Program/ProgramsTab.tsx
+++ b/vsm-app/components/Program/ProgramsTab.tsx
@@ -647,7 +647,12 @@ const ProgramsTab: NextPage = () => {
           programId: payload.programId,
           programTitle: payload.programTitle,
           latestFromTxServer: payload.latestFromTxServer
-        }
+        },
+        onSuccess: async () => {
+          toast.success(`Program ${payload.programTitle} released successfully.`)
+          await mutate()
+        },
+        onFailure: (error: string) => toast.error(`Release failed for ${payload.programTitle}: ${error}`)
       })
       await mutate()
       toast.success(`Program ${payload.programTitle} release in progress.`)

--- a/vsm-app/helpers/fhirResourceHelper.ts
+++ b/vsm-app/helpers/fhirResourceHelper.ts
@@ -33,8 +33,14 @@ type AddTerminologyEndpointToParameters = {
 }
 
 const addTerminologyEndpointToParameters = async ({parameters, address, userId }: AddTerminologyEndpointToParameters): Promise<fhir4.Parameters> => {
-  const vsCreds = await tsCredentialService.getVsacCredentials(userId)
-  
+  let vsCreds
+  try {
+    vsCreds = await tsCredentialService.getVsacCredentials(userId)
+  } catch {
+    // No credentials stored — proceed without a terminology endpoint
+    return parameters
+  }
+
   const updatedParameters = structuredClone(parameters)
   const endpointWithVsacCredentials: fhir4.Endpoint = {
     resourceType: 'Endpoint',

--- a/vsm-app/worker/ProgramReleaseQueue.ts
+++ b/vsm-app/worker/ProgramReleaseQueue.ts
@@ -27,10 +27,12 @@ type ProgramReleaseQueueJobData = {
 ProgramReleaseQueue.process(async function (job: Queue.Job<ProgramReleaseQueueJobData>, done) {
   const { releaseAsVersion, programId, releaseDescription = '', releaseLabel = '', effectiveStartDate, latestFromTxServer, userId } = job.data
   Logger.getLogger().info('Begin Release Job for Program Id: ' + job.data.programId)
-  
+
   const cache = await Cache.getInstance()
-  const cacheKey = `user:${userId}:job:${job.id}`  
-  
+  const cacheKey = `user:${userId}:job:${job.id}`
+
+  try {
+
   let program: fhir4.Library | undefined
   try {
     program = (await FhirClient.getInstance().read({
@@ -113,6 +115,13 @@ ProgramReleaseQueue.process(async function (job: Queue.Job<ProgramReleaseQueueJo
     Logger.getLogger().info('Finished')
     await cache.hset(cacheKey, 'status', JOB_STATUS.COMPLETED)
     return done(null, { response: "Finished" })
+  }
+
+  } catch (e: any) {
+    const error = e?.message || 'Unknown error during release'
+    Logger.getLogger().error('Release job failed with unhandled error: ' + error)
+    await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
+    done(null, { error })
   }
 })
 


### PR DESCRIPTION
fixes #638 

Three related issues caused the release job to silently fail and leave the UI in an
infinite spinner state:

- ProgramReleaseQueue.ts — The entire job body was wrapped in a top-level try/catch. Previously, unhandled exceptions would crash the worker without updating the job's cache status, so the UI had no way to detect failure. The outer catch now
sets the job status to FAILED and records the error message.
- fhirResourceHelper.ts — getVsacCredentials was called without error handling. If no credentials were stored, it would throw and abort parameter construction. The call is now wrapped in a try/catch that returns early without a terminology endpoint
when credentials are unavailable.
- ProgramsTab.tsx — onSuccess and onFailure callbacks were added to the release job dispatch so the UI displays a success or failure toast and refreshes the program list when the job completes, rather than waiting indefinitely.