### PR TITLE
Aigning $data-requirements call with clinical-reasoning updates 

### DIFF
--- a/pw-e2e/package-lock.json
+++ b/pw-e2e/package-lock.json
@@ -1,97 +1,57 @@
 {
   "name": "pw-e2e",
   "version": "1.0.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "pw-e2e",
-      "version": "1.0.0",
-      "license": "ISC",
-      "devDependencies": {
-        "@playwright/test": "^1.50.0",
-        "@types/node": "^22.10.9"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+  "dependencies": {
+    "@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "requires": {
+        "playwright": "1.58.2"
+      },
       "dependencies": {
-        "playwright": "1.50.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "playwright": {
+          "version": "1.58.2",
+          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+          "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2",
+            "playwright-core": "1.58.2"
+          }
+        }
       }
     },
-    "node_modules/@types/node": {
-      "version": "22.10.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.9.tgz",
-      "integrity": "sha512-Ir6hwgsKyNESl/gLOcEz3krR4CBGgliDqBQ2ma4wIhEx0w+xnoeTq3tdrNw15kU3SxogDjOgv9sqdtLW8mIHaw==",
+    "@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
+      "requires": {
+        "undici-types": "~6.21.0"
       }
     },
-    "node_modules/fsevents": {
+    "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "optional": true
     },
-    "node_modules/playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.50.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
+    "playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true
     },
-    "node_modules/playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     }
   }
 }

--- a/vsm-app/package-lock.json
+++ b/vsm-app/package-lock.json
@@ -130,7 +130,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -848,7 +847,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
       "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -912,7 +910,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2547,7 +2544,6 @@
       "integrity": "sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^28.1.3",
         "@jest/expect": "^28.1.3",
@@ -3129,7 +3125,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -3235,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -3972,7 +3966,6 @@
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -4090,7 +4083,8 @@
       "version": "1.26.6",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
       "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4103,7 +4097,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
       "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4645,7 +4638,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5371,7 +5363,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6010,7 +6001,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -6035,8 +6025,7 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -6637,7 +6626,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -6797,7 +6785,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -6918,7 +6905,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9127,7 +9113,6 @@
       "integrity": "sha512-TZR+tHxopPhzw3c3560IJXZWLNHgpcz1Zh0w5A65vynLGNcg/5pZ+VildAd7+XGOu6jd58XMY/HNn0IkZIXVXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^28.1.0",
         "import-local": "^3.0.2",
@@ -11689,7 +11674,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12012,7 +11996,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
       "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.12",
         "@swc/helpers": "0.5.15",
@@ -12914,7 +12897,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
       "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -13193,7 +13175,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13235,7 +13216,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13248,8 +13228,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-select": {
       "version": "5.10.2",
@@ -14374,7 +14353,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -14687,7 +14665,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14987,7 +14964,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/vsm-app/tests/worker/DependencyQueue.spec.ts
+++ b/vsm-app/tests/worker/DependencyQueue.spec.ts
@@ -1,0 +1,488 @@
+/**
+ * @jest-environment node
+ */
+
+import { Readable } from 'stream'
+import zlib from 'zlib'
+
+// ---------------------------------------------------------------------------
+// Helpers – build a real gzipped tarball containing an IG JSON resource
+// ---------------------------------------------------------------------------
+function createIGTarball(ig: Record<string, unknown>): Promise<Buffer> {
+  const tar = require('tar-stream')
+  return new Promise((resolve, reject) => {
+    const pack = tar.pack()
+    pack.entry({ name: 'package/ImplementationGuide-test.json' }, JSON.stringify(ig))
+    pack.finalize()
+
+    const chunks: Buffer[] = []
+    const gzip = zlib.createGzip()
+    pack.pipe(gzip)
+    gzip.on('data', (chunk: Buffer) => chunks.push(chunk))
+    gzip.on('end', () => resolve(Buffer.concat(chunks)))
+    gzip.on('error', reject)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Mocks – must be set up before the module under test is imported
+// ---------------------------------------------------------------------------
+
+// Bull: capture the processor callback registered by DependencyQueue.process()
+let capturedProcessor: (job: any, done: jest.Mock) => Promise<any>
+jest.mock('bull', () => {
+  return jest.fn().mockImplementation(() => ({
+    process: jest.fn((fn: any) => {
+      capturedProcessor = fn
+    }),
+    add: jest.fn()
+  }))
+})
+
+// FhirClient
+const mockRead = jest.fn()
+const mockUpdate = jest.fn()
+jest.mock('../../backend/clients/FhirCdrClient', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      read: mockRead,
+      update: mockUpdate,
+      baseUrl: 'http://fhir-server',
+      customHeaders: {}
+    }))
+  }
+}))
+
+// Undici – used by callDataRequirements and callInferManifestParameters
+const mockUndiciFetch = jest.fn()
+jest.mock('undici', () => ({
+  fetch: mockUndiciFetch,
+  Agent: jest.fn().mockImplementation(() => ({}))
+}))
+
+// Cache
+const mockHset = jest.fn()
+jest.mock('../../cache', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn().mockResolvedValue({
+      hset: mockHset,
+      sadd: jest.fn(),
+      expire: jest.fn()
+    })
+  }
+}))
+
+// Logger – silence all output
+jest.mock('../../helpers/server/logger', () => ({
+  __esModule: true,
+  default: {
+    getLogger: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }))
+  }
+}))
+
+// Config
+jest.mock('../../config', () => ({
+  QUEUE_REDIS_URL: 'redis://localhost:6379',
+  DEFAULT_JOB_CONFIG: {},
+  JOB_EXPIRATION: 3600
+}))
+
+// Constants
+jest.mock('../../constants', () => ({
+  JOB_STATUS: { IN_PROGRESS: 'in_progress', COMPLETED: 'completed', FAILED: 'failed' },
+  JOB_TYPE: { FETCH_DEPENDENCIES: 'fetch_dependencies' }
+}))
+
+// Import the module – triggers DependencyQueue.process() which sets capturedProcessor
+require('../../worker/DependencyQueue')
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+const SAMPLE_IG: fhir4.ImplementationGuide = {
+  resourceType: 'ImplementationGuide',
+  id: 'hl7.fhir.us.core-6.1.0',
+  url: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core',
+  version: '6.1.0',
+  name: 'USCore',
+  title: 'US Core',
+  status: 'active',
+  packageId: 'hl7.fhir.us.core',
+  fhirVersion: ['4.0.1']
+}
+
+const SAMPLE_MODULE_DEFINITION: fhir4.Library = {
+  resourceType: 'Library',
+  id: 'module-def-1',
+  status: 'active',
+  type: { coding: [{ code: 'module-definition' }] }
+}
+
+const SAMPLE_MANIFEST_LIBRARY: fhir4.Library = {
+  resourceType: 'Library',
+  id: 'manifest-1',
+  status: 'active',
+  type: { coding: [{ code: 'manifest' }] },
+  contained: [
+    {
+      resourceType: 'Parameters',
+      id: 'expansion-parameters',
+      parameter: [
+        { name: 'system-version', valueString: 'http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901' },
+        { name: 'canonicalVersion', valueString: 'http://hl7.org/fhir/us/core/ValueSet/birthsex|6.1.0' }
+      ]
+    } as fhir4.Parameters
+  ],
+  relatedArtifact: [
+    { type: 'depends-on', resource: 'http://hl7.org/fhir/us/core/ValueSet/birthsex|6.1.0' }
+  ]
+}
+
+function createMockJob(overrides: Partial<{ igCanonical: string; igPackageId: string; userId: string }> = {}) {
+  return {
+    id: 'job-123',
+    data: {
+      igCanonical: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|6.1.0',
+      igPackageId: 'hl7.fhir.us.core',
+      userId: 'user-1',
+      ...overrides
+    },
+    progress: jest.fn()
+  }
+}
+
+function makeFhir404() {
+  const err: any = new Error('Not Found')
+  err.response = { status: 404 }
+  return err
+}
+
+// Helper to mock undici responses for $data-requirements (GET) and $infer-manifest-parameters (POST)
+function mockUndiciFetchForSuccess() {
+  mockUndiciFetch.mockImplementation(async (url: string) => {
+    if (url.includes('$data-requirements')) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => SAMPLE_MODULE_DEFINITION
+      }
+    }
+    if (url.includes('$infer-manifest-parameters')) {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => SAMPLE_MANIFEST_LIBRARY
+      }
+    }
+    throw new Error(`Unexpected undici fetch URL: ${url}`)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('DependencyQueue processor', () => {
+  // -----------------------------------------------------------------------
+  // ensureIGOnFhirServer
+  // -----------------------------------------------------------------------
+  describe('Step 1: ensureIGOnFhirServer', () => {
+    test('cache hit – uses IG already on FHIR server, skips Simplifier download', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      // FhirClient.read was called with the right resourceType + id
+      expect(mockRead).toHaveBeenCalledWith({
+        resourceType: 'ImplementationGuide',
+        id: 'hl7.fhir.us.core-6.1.0'
+      })
+
+      // No PUT since the IG was already cached
+      expect(mockUpdate).not.toHaveBeenCalled()
+
+      // Job completed (done called with result containing igName)
+      expect(done).toHaveBeenCalledTimes(1)
+      const result = done.mock.calls[0][1]
+      expect(result.igName).toBe('USCore')
+      expect(result.igTitle).toBe('US Core')
+    })
+
+    test('cache miss – downloads from Simplifier, PUTs to FHIR server', async () => {
+      // First call to read → 404
+      mockRead.mockRejectedValue(makeFhir404())
+      mockUpdate.mockResolvedValue({ ...SAMPLE_IG })
+      mockUndiciFetchForSuccess()
+
+      // Build a real tarball containing the IG
+      const igForTarball = { ...SAMPLE_IG, id: 'original-id' }
+      const tarball = await createIGTarball(igForTarball)
+      ;(global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => tarball.buffer.slice(tarball.byteOffset, tarball.byteOffset + tarball.byteLength)
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      // Simplifier download was called
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://packages.simplifier.net/hl7.fhir.us.core/6.1.0'
+      )
+
+      // PUT was called with the computed resource ID
+      expect(mockUpdate).toHaveBeenCalledWith({
+        resourceType: 'ImplementationGuide',
+        id: 'hl7.fhir.us.core-6.1.0',
+        body: expect.objectContaining({
+          resourceType: 'ImplementationGuide',
+          id: 'hl7.fhir.us.core-6.1.0'
+        })
+      })
+
+      // Job completed successfully
+      expect(done).toHaveBeenCalledTimes(1)
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('fhir-operations')
+    })
+
+    test('Simplifier download failure – returns graceful fallback', async () => {
+      mockRead.mockRejectedValue(makeFhir404())
+      ;(global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      // No PUT attempted
+      expect(mockUpdate).not.toHaveBeenCalled()
+
+      // Job returns fallback result
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('none')
+      expect(result.warnings[0]).toContain('Could not download')
+    })
+
+    test('PUT failure – returns graceful fallback', async () => {
+      mockRead.mockRejectedValue(makeFhir404())
+      mockUpdate.mockRejectedValue(new Error('Server error'))
+
+      const igForTarball = { ...SAMPLE_IG }
+      const tarball = await createIGTarball(igForTarball)
+      ;(global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => tarball.buffer.slice(tarball.byteOffset, tarball.byteOffset + tarball.byteLength)
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('none')
+      expect(result.warnings[0]).toContain('Could not download')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // callDataRequirements
+  // -----------------------------------------------------------------------
+  describe('Step 2: callDataRequirements', () => {
+    test('uses GET method, not POST', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      // Find the $data-requirements call
+      const drCall = mockUndiciFetch.mock.calls.find(
+        ([url]: [string]) => url.includes('$data-requirements')
+      )
+      expect(drCall).toBeDefined()
+      expect(drCall[1].method).toBe('GET')
+    })
+
+    test('calls instance-level URL with igResourceId', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const drCall = mockUndiciFetch.mock.calls.find(
+        ([url]: [string]) => url.includes('$data-requirements')
+      )
+      expect(drCall[0]).toBe(
+        'http://fhir-server/ImplementationGuide/hl7.fhir.us.core-6.1.0/$data-requirements'
+      )
+    })
+
+    test('does not send a body or Content-Type header', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const drCall = mockUndiciFetch.mock.calls.find(
+        ([url]: [string]) => url.includes('$data-requirements')
+      )
+      expect(drCall[1].body).toBeUndefined()
+      expect(drCall[1].headers['Content-Type']).toBeUndefined()
+    })
+
+    test('failure returns fallback result with igName/igTitle preserved', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetch.mockImplementation(async (url: string) => {
+        if (url.includes('$data-requirements')) {
+          return { ok: false, status: 500, statusText: 'Error', text: async () => 'Server error' }
+        }
+        throw new Error(`Unexpected URL: ${url}`)
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('none')
+      expect(result.igName).toBe('USCore')
+      expect(result.igTitle).toBe('US Core')
+      expect(result.warnings[0]).toContain('$data-requirements operation failed')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Full success flow
+  // -----------------------------------------------------------------------
+  describe('full success flow', () => {
+    test('returns manifest data with codeSystems, valueSets, and relatedArtifact', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('fhir-operations')
+      expect(result.igName).toBe('USCore')
+      expect(result.igTitle).toBe('US Core')
+
+      // codeSystems from system-version parameter
+      expect(result.manifestData.codeSystems['http://snomed.info/sct']).toBeDefined()
+
+      // valueSets from canonicalVersion parameter
+      expect(result.manifestData.valueSets['http://hl7.org/fhir/us/core/ValueSet/birthsex']).toBeDefined()
+
+      // relatedArtifact passed through
+      expect(result.manifestData.relatedArtifact).toHaveLength(1)
+    })
+
+    test('reports progress for all three steps', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetchForSuccess()
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      // 3 progress steps + 1 final
+      expect(job.progress).toHaveBeenCalledTimes(4)
+      expect(job.progress).toHaveBeenCalledWith(expect.objectContaining({ current: 1, total: 3 }))
+      expect(job.progress).toHaveBeenCalledWith(expect.objectContaining({ current: 2, total: 3 }))
+      expect(job.progress).toHaveBeenCalledWith(expect.objectContaining({ current: 3, total: 3 }))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Edge cases
+  // -----------------------------------------------------------------------
+  describe('edge cases', () => {
+    test('missing version in canonical returns error', async () => {
+      const job = createMockJob({ igCanonical: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core' })
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.error).toContain('version')
+    })
+
+    test('parses canonicalVersion from valueCanonical (spec-correct)', async () => {
+      const manifestWithValueCanonical = {
+        ...SAMPLE_MANIFEST_LIBRARY,
+        contained: [
+          {
+            resourceType: 'Parameters',
+            id: 'expansion-parameters',
+            parameter: [
+              { name: 'system-version', valueString: 'http://snomed.info/sct|20230901' },
+              { name: 'canonicalVersion', valueCanonical: 'http://example.org/ValueSet/test-vs|1.0.0' }
+            ]
+          }
+        ]
+      }
+
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetch.mockImplementation(async (url: string) => {
+        if (url.includes('$data-requirements')) {
+          return { ok: true, status: 200, statusText: 'OK', json: async () => SAMPLE_MODULE_DEFINITION }
+        }
+        if (url.includes('$infer-manifest-parameters')) {
+          return { ok: true, status: 200, statusText: 'OK', json: async () => manifestWithValueCanonical }
+        }
+        throw new Error(`Unexpected URL: ${url}`)
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.manifestData.valueSets['http://example.org/ValueSet/test-vs']).toEqual(['1.0.0'])
+    })
+
+    test('$infer-manifest-parameters failure returns fallback', async () => {
+      mockRead.mockResolvedValue(SAMPLE_IG)
+      mockUndiciFetch.mockImplementation(async (url: string) => {
+        if (url.includes('$data-requirements')) {
+          return { ok: true, status: 200, statusText: 'OK', json: async () => SAMPLE_MODULE_DEFINITION }
+        }
+        if (url.includes('$infer-manifest-parameters')) {
+          return { ok: false, status: 500, statusText: 'Error', text: async () => 'Server error' }
+        }
+        throw new Error(`Unexpected URL: ${url}`)
+      })
+
+      const job = createMockJob()
+      const done = jest.fn()
+      await capturedProcessor(job, done)
+
+      const result = done.mock.calls[0][1]
+      expect(result.source).toBe('none')
+      expect(result.warnings[0]).toContain('$infer-manifest-parameters operation failed')
+    })
+  })
+})

--- a/vsm-app/worker/DependencyQueue.ts
+++ b/vsm-app/worker/DependencyQueue.ts
@@ -113,37 +113,80 @@ async function downloadAndExtractIG(igPackageId: string, igVersion: string): Pro
 }
 
 /**
- * Call $data-requirements operation on ImplementationGuide
+ * Ensure the ImplementationGuide resource exists on the FHIR server.
+ * Uses a cache-first approach: tries to read the IG from the server,
+ * and only downloads from Simplifier + PUTs if not found.
+ *
+ * Cache assumption: Published IG package versions on Simplifier are immutable.
+ * Once cached on the FHIR server, the IG is always considered valid.
+ * If pre-release/CI build versions need support in the future, a cache
+ * invalidation strategy would be needed.
+ */
+async function ensureIGOnFhirServer(
+  igPackageId: string,
+  igVersion: string
+): Promise<{ ig: fhir4.ImplementationGuide; igResourceId: string } | null> {
+  const igResourceId = `${igPackageId}-${igVersion}`
+
+  // Try to read from FHIR server (cache hit)
+  try {
+    Logger.getLogger().info(`Checking FHIR server for ImplementationGuide/${igResourceId}`)
+    const existing = await FhirClient.getInstance().read({
+      resourceType: 'ImplementationGuide',
+      id: igResourceId
+    }) as fhir4.ImplementationGuide
+
+    if (existing?.resourceType === 'ImplementationGuide') {
+      Logger.getLogger().info(`Cache hit: ImplementationGuide/${igResourceId} already on FHIR server`)
+      return { ig: existing, igResourceId }
+    }
+  } catch (err: any) {
+    // 404 or other error means we need to download
+    Logger.getLogger().info(`ImplementationGuide/${igResourceId} not found on FHIR server (${err.response?.status || err.message}), downloading from Simplifier`)
+  }
+
+  // Download from Simplifier
+  const ig = await downloadAndExtractIG(igPackageId, igVersion)
+  if (!ig) {
+    return null
+  }
+
+  // Set the ID and PUT to FHIR server
+  ig.id = igResourceId
+  try {
+    Logger.getLogger().info(`Caching ImplementationGuide/${igResourceId} on FHIR server`)
+    await FhirClient.getInstance().update({
+      resourceType: 'ImplementationGuide',
+      id: igResourceId,
+      body: ig
+    })
+    Logger.getLogger().info(`Cached ImplementationGuide/${igResourceId} on FHIR server`)
+  } catch (err: any) {
+    Logger.getLogger().error(`Failed to PUT ImplementationGuide/${igResourceId}: ${err.message || err}`)
+    return null
+  }
+
+  return { ig, igResourceId }
+}
+
+/**
+ * Call $data-requirements operation on ImplementationGuide (instance-level GET)
  * Uses undici fetch with extended timeouts for long-running operations
  */
-async function callDataRequirements(ig: fhir4.ImplementationGuide): Promise<fhir4.Library | null> {
+async function callDataRequirements(igResourceId: string): Promise<fhir4.Library | null> {
   let response: any = null
   try {
-    Logger.getLogger().info(`Calling $data-requirements on IG: ${ig.id}`)
-    Logger.getLogger().info(`IG URL: ${ig.url}, Version: ${ig.version}`)
+    Logger.getLogger().info(`Calling $data-requirements on ImplementationGuide/${igResourceId}`)
 
     // Use undici fetch with long timeouts for this operation
     const { fetch: f, Agent } = require('undici')
     const baseUrl = FhirClient.getInstance().baseUrl
-    const url = `${baseUrl}/ImplementationGuide/$data-requirements`
+    const url = `${baseUrl}/ImplementationGuide/${igResourceId}/$data-requirements`
 
-    // Wrap IG in Parameters resource
-    const parametersInput: fhir4.Parameters = {
-      resourceType: 'Parameters',
-      parameter: [
-        {
-          name: 'implementationGuide',
-          resource: ig
-        }
-      ]
-    }
-
-    Logger.getLogger().info(`Making POST request to: ${url}`)
-    Logger.getLogger().info(`Request body size: ${JSON.stringify(parametersInput).length} bytes`)
+    Logger.getLogger().info(`Making GET request to: ${url}`)
 
     response = await f(url, {
-      method: 'POST',
-      body: JSON.stringify(parametersInput),
+      method: 'GET',
       dispatcher: new Agent({
         connectTimeout: 10 * 60 * 1000,  // 10 minutes
         headersTimeout: 10 * 60 * 1000,
@@ -151,7 +194,6 @@ async function callDataRequirements(ig: fhir4.ImplementationGuide): Promise<fhir
         keepAliveMaxTimeout: 10 * 60 * 1000
       }),
       headers: {
-        'Content-Type': 'application/fhir+json',
         'Accept': 'application/fhir+json',
         ...FhirClient.getInstance().customHeaders
       }
@@ -320,9 +362,10 @@ async function callInferManifestParameters(moduleDefinition: fhir4.Library): Pro
           }
         }
       }
-      // ValueSet versions use canonicalVersion parameter with valueCanonical (canonical|version)
-      else if (param.name === 'canonicalVersion' && param.valueCanonical) {
-        const [canonical, version] = param.valueCanonical.split('|')
+      // ValueSet versions use canonicalVersion parameter (canonical|version)
+      // Accept both valueCanonical (spec-correct) and valueString (current server behavior)
+      else if (param.name === 'canonicalVersion' && (param.valueCanonical || param.valueString)) {
+        const [canonical, version] = (param.valueCanonical || param.valueString)!.split('|')
         if (canonical) {
           if (!valueSets[canonical]) {
             valueSets[canonical] = []
@@ -417,18 +460,18 @@ DependencyQueue.process(async function (job: any, done) {
 
     const warnings: string[] = []
 
-    // Step 1: Download and extract ImplementationGuide from package
-    Logger.getLogger().info('Step 1: Downloading and extracting ImplementationGuide')
+    // Step 1: Ensure ImplementationGuide exists on FHIR server
+    Logger.getLogger().info('Step 1: Ensuring ImplementationGuide is available on FHIR server')
     const progress1 = {
-      step: 'Downloading and extracting ImplementationGuide',
+      step: 'Ensuring ImplementationGuide is available on FHIR server',
       current: 1,
       total: 3
     }
     job.progress(progress1)
     Logger.getLogger().info(`Progress updated: ${JSON.stringify(progress1)}`)
-    const ig = await downloadAndExtractIG(igPackageId, igVersion)
+    const ensureResult = await ensureIGOnFhirServer(igPackageId, igVersion)
 
-    if (!ig) {
+    if (!ensureResult) {
       const result: DependencyJobResult = {
         manifestData: { codeSystems: {}, valueSets: {} },
         igName: '',
@@ -439,6 +482,8 @@ DependencyQueue.process(async function (job: any, done) {
       await cache.hset(cacheKey, 'status', JOB_STATUS.COMPLETED, 'result', JSON.stringify(result))
       return done(null, result)
     }
+
+    const { ig, igResourceId } = ensureResult
 
     // Extract IG name and title for auto-population
     const igName = ig.name || ''
@@ -453,7 +498,7 @@ DependencyQueue.process(async function (job: any, done) {
     }
     job.progress(progress2)
     Logger.getLogger().info(`Progress updated: ${JSON.stringify(progress2)}`)
-    const moduleDefinition = await callDataRequirements(ig)
+    const moduleDefinition = await callDataRequirements(igResourceId)
 
     if (!moduleDefinition) {
       const result: DependencyJobResult = {


### PR DESCRIPTION
The $data-requirements operation was incorrectly POSTing the IG resource  inline, which doesn't match the CRMI spec or the server's idempotent (GET-only) registration. Now ensures the IG exists on the FHIR server (cache-first via GET, download and PUT if not found) and calls GET /ImplementationGuide/{id}/$data-requirements. Also fixes ValueSet parsing to accept both valueString and valueCanonical for canonicalVersion parameters (this is a bug in the clinical-reasoning $infer-manifest-parameters, which I will fix separately, but no real harm in supporting valueString for now). 