### PR TITLE
Fix manifest parsing to support valueCanonical format

### DIFF
--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -332,7 +332,7 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   // Parse CodeSystem versions
   const systemVersions = parameterResource?.parameter?.filter((i) => i.name === 'system-version')
   systemVersions?.forEach((i) => {
-    const paramValue = i.valueString || i.valueUri || ''
+    const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''
     const [system, version = ''] = decodeURI(paramValue).split('|') || []
     if (codeSystems[system]) {
       codeSystems[system].push(version)
@@ -344,7 +344,7 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   // Parse ValueSet versions (NEW for VSPs)
   const valuesetVersions = parameterResource?.parameter?.filter((i) => i.name === 'valueset-version')
   valuesetVersions?.forEach((i) => {
-    const paramValue = i.valueString || i.valueUri || ''
+    const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''
     const [canonical, version = ''] = decodeURI(paramValue).split('|') || []
     if (valueSets[canonical]) {
       valueSets[canonical].push(version)

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -330,6 +330,8 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   ) as fhir4.Parameters
 
   // Parse CodeSystem versions
+  // Note: $release-manifest returns valueCanonical (e.g. "http://loinc.org|2.81"),
+  // while manual edits and $infer-manifest-parameters may use valueString or valueUri.
   const systemVersions = parameterResource?.parameter?.filter((i) => i.name === 'system-version')
   systemVersions?.forEach((i) => {
     const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''


### PR DESCRIPTION
Summary                                                                                                                             
                                                                                                                                      
  - The FHIR $release-manifest operation returns expansion parameters using valueCanonical (e.g., "valueCanonical": "http://loinc.org|2.81"), while manual edits and $infer-manifest-parameters use valueString or valueUri
  - getVSPManifestVersions only checked valueString and valueUri, causing CodeSystem and ValueSet URLs to appear blank in the manifest list after a VSP release                                                                                                           
  - Added valueCanonical as the first fallback in both system-version and valueset-version parameter parsing
                                                                                                                                      
Test plan                                                                                                                           
                                                                                                                                      
  - Release a VSP via $release-manifest and verify CodeSystem/ValueSet URLs display correctly in the manifest table                   
  - Verify manually edited manifest entries (using valueString) still display correctly
  - Run npx jest --no-coverage  