### PR TITLE
Fix blank manifest page when VSAC data is unavailable 

### DIFF
--- a/vsm-app/components/EditManifestDetails/index.tsx
+++ b/vsm-app/components/EditManifestDetails/index.tsx
@@ -201,8 +201,17 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
     setIsUpdating(false)
   }
 
+  if (isLoading) {
+    return <LoadingIndicator />
+  }
+
   if (selectOptions.length === 0) {
-    return null // Fixes a nextjs hydration error
+    return (
+      <ErrorMessage
+        error="No CodeSystem or ValueSet data available from the terminology server. Please check your VSAC credentials in Settings."
+        severity="warning"
+      />
+    )
   }
 
   const onClickAddHandler = (newVersion: string, system?: string) => {


### PR DESCRIPTION
Summary

  - The manifest edit page rendered completely blank when the VSAC terminology server was slow, unreachable, or returned no data - the component returned null while waiting for SWR to resolve
  - Added a loading indicator while data is being fetched
  - Show a warning message prompting the user to check VSAC credentials when no data is returned

Test plan

  - Navigate to a VSP manifest edit page with valid VSAC credentials — should load normally
  - Remove/invalidate VSAC credentials and navigate to manifest page — should show warning instead of blank page
  - Run npx jest --no-coverage
