### PR TITLE
VSP async release with notification polling

### DIFF
--- a/vsm-app/components/VSPDetails/index.tsx
+++ b/vsm-app/components/VSPDetails/index.tsx
@@ -18,6 +18,8 @@ import ManifestDetailTable from '@/components/ManifestDetailTable'
 import VSPMetadata from '@/components/VSPMetadata'
 import { Row, Col, MetadataTitle, ManifestContainer } from './styles'
 import { apiFetch } from '@/utils'
+import NotificationStore from '@/store/NotificationStore'
+import { JOB_TYPE } from '@/constants'
 
 const ActionButtonContainer = styled.div`
   display: flex;
@@ -126,28 +128,41 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
   // Action handlers
   const handleReleaseDraft = async () => {
     setReleaseLoading(true)
-
-    const releaseParameters: fhir4.Parameters = {
-      resourceType: 'Parameters',
-      parameter: []
-    }
-
-    const parameters = JSON.stringify(releaseParameters)
-    const result = await apiFetch(`/api/value-set-packages/${id}/release`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: parameters })
-
-    if (!result.ok) {
-      const res = await result.json()
-      setError({
-        error: [`Error occurred while releasing VSP: ${id}.`, `${res.error}`]
+    try {
+      const result = await apiFetch(`/api/value-set-packages/${id}/release`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latestFromTxServer: false })
       })
+
+      if (!result.ok) {
+        const res = await result.json()
+        setError({
+          error: [`Error occurred while releasing VSP: ${id}.`, `${res.error}`]
+        })
+      } else {
+        const res = await result.json()
+        NotificationStore.addJob({
+          jobId: res.id,
+          jobType: JOB_TYPE.RELEASE,
+          metadata: {
+            programId: id,
+            programTitle: currentVSP?.title || id,
+            latestFromTxServer: false
+          },
+          onSuccess: async () => {
+            toast.success(`VSP ${id} released successfully.`)
+            router.replace(router.asPath)
+          },
+          onFailure: (error: string) => toast.error(`Release failed for VSP ${id}: ${error}`)
+        })
+        toast.info('VSP release in progress.')
+      }
+    } catch (e) {
+      setError({ error: ['An unexpected error occurred.'] })
+    } finally {
       setReleaseLoading(false)
       setReleaseModalOpen(false)
-    } else {
-      setReleaseLoading(false)
-      setReleaseModalOpen(false)
-      toast.success(`VSP ${id} released successfully.`)
-      // Refresh the page to get updated VSP
-      router.replace(router.asPath)
     }
   }
 

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -332,7 +332,7 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   // Parse CodeSystem versions
   const systemVersions = parameterResource?.parameter?.filter((i) => i.name === 'system-version')
   systemVersions?.forEach((i) => {
-    const paramValue = i.valueString || i.valueUri || ''
+    const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''
     const [system, version = ''] = decodeURI(paramValue).split('|') || []
     if (codeSystems[system]) {
       codeSystems[system].push(version)
@@ -344,7 +344,7 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   // Parse ValueSet versions (NEW for VSPs)
   const valuesetVersions = parameterResource?.parameter?.filter((i) => i.name === 'valueset-version')
   valuesetVersions?.forEach((i) => {
-    const paramValue = i.valueString || i.valueUri || ''
+    const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''
     const [canonical, version = ''] = decodeURI(paramValue).split('|') || []
     if (valueSets[canonical]) {
       valueSets[canonical].push(version)

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -330,6 +330,8 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   ) as fhir4.Parameters
 
   // Parse CodeSystem versions
+  // Note: $release-manifest returns valueCanonical (e.g. "http://loinc.org|2.81"),
+  // while manual edits and $infer-manifest-parameters may use valueString or valueUri.
   const systemVersions = parameterResource?.parameter?.filter((i) => i.name === 'system-version')
   systemVersions?.forEach((i) => {
     const paramValue = i.valueCanonical || i.valueString || i.valueUri || ''

--- a/vsm-app/pages/api/jobs/[id].ts
+++ b/vsm-app/pages/api/jobs/[id].ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import PackageQueue from '@/worker/PackageQueue'
 import DependencyQueue from '@/worker/DependencyQueue'
 import VSPPackageQueue from '@/worker/VSPPackageQueue'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
 
 const getJobStatus = async (req: NextApiRequest, res: NextApiResponse) => {
   const jobId = req.query.id as string
@@ -21,6 +22,11 @@ const getJobStatus = async (req: NextApiRequest, res: NextApiResponse) => {
   // If still not found, try VSPPackageQueue
   if (!job) {
     job = await VSPPackageQueue.getJob(jobId)
+  }
+
+  // If still not found, try VSPReleaseQueue
+  if (!job) {
+    job = await VSPReleaseQueue.getJob(jobId)
   }
 
   if (!job) {

--- a/vsm-app/pages/api/jobs/[id]/cancel.ts
+++ b/vsm-app/pages/api/jobs/[id]/cancel.ts
@@ -6,6 +6,7 @@ import DependencyQueue from '@/worker/DependencyQueue'
 import PackageQueue from '@/worker/PackageQueue'
 import VSPPackageQueue from '@/worker/VSPPackageQueue'
 import ProgramReleaseQueue from '@/worker/ProgramReleaseQueue'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
 import ChangeLogQueue from '@/worker/ChangeLogQueue'
 import VSPDiffQueue from '@/worker/VSPDiffQueue'
 import Cache from '@/cache'
@@ -67,8 +68,12 @@ const cancelJob = async (req: NextApiRequest, res: NextApiResponse<CancelJobResp
         }
         break
       case JOB_TYPE.RELEASE:
-        queue = ProgramReleaseQueue
+        queue = VSPReleaseQueue
         job = await queue.getJob(jobId)
+        if (!job) {
+          queue = ProgramReleaseQueue
+          job = await queue.getJob(jobId)
+        }
         break
       case JOB_TYPE.CHANGE_LOG:
         // For changelog jobs, try both queues (Programs use ChangeLogQueue, VSPs use VSPDiffQueue)

--- a/vsm-app/pages/api/jobs/[id]/result.ts
+++ b/vsm-app/pages/api/jobs/[id]/result.ts
@@ -6,6 +6,8 @@ import PackageQueue from '@/worker/PackageQueue'
 import VSPPackageQueue from '@/worker/VSPPackageQueue'
 import ChangeLogQueue from '@/worker/ChangeLogQueue'
 import DependencyQueue from '@/worker/DependencyQueue'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
+import ProgramReleaseQueue from '@/worker/ProgramReleaseQueue'
 import Cache from '@/cache'
 import { JOB_TYPE } from '@/constants'
 import { VSMSession } from '@/helpers/rolesHelper'
@@ -60,6 +62,15 @@ const getJobResult = async (req: NextApiRequest, res: NextApiResponse, session: 
         if (!job) {
           Logger.getLogger().info(`Not in VSPPackageQueue, checking PackageQueue`)
           job = await PackageQueue.getJob(jobId)
+        }
+        Logger.getLogger().info(`Job found in queue: ${!!job}`)
+        break
+      case JOB_TYPE.RELEASE:
+        Logger.getLogger().info(`Checking VSPReleaseQueue for job ${jobId}`)
+        job = await VSPReleaseQueue.getJob(jobId)
+        if (!job) {
+          Logger.getLogger().info(`Not in VSPReleaseQueue, checking ProgramReleaseQueue`)
+          job = await ProgramReleaseQueue.getJob(jobId)
         }
         Logger.getLogger().info(`Job found in queue: ${!!job}`)
         break

--- a/vsm-app/pages/api/jobs/index.ts
+++ b/vsm-app/pages/api/jobs/index.ts
@@ -7,6 +7,7 @@ import PackageQueue from '@/worker/PackageQueue'
 import { Jobs, JobData } from '@/types/jobTypes'
 import ChangeLogQueue from '@/worker/ChangeLogQueue'
 import ProgramReleaseQueue from '@/worker/ProgramReleaseQueue'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
 import VSPDiffQueue from '@/worker/VSPDiffQueue'
 import VSPPackageQueue from '@/worker/VSPPackageQueue'
 
@@ -53,6 +54,7 @@ const deleteAllJobs = async (req: NextApiRequest, res: NextApiResponse, session:
   await Promise.all(jobIds.map((jobId) => ChangeLogQueue.getJob(jobId).then((job) => job?.remove())))
   await Promise.all(jobIds.map((jobId) => VSPDiffQueue.getJob(jobId).then((job) => job?.remove())))
   await Promise.all(jobIds.map((jobId) => ProgramReleaseQueue.getJob(jobId).then((job) => job?.remove())))
+  await Promise.all(jobIds.map((jobId) => VSPReleaseQueue.getJob(jobId).then((job) => job?.remove())))
 
   await multiRun.exec()
   await cache.del(`user:${userId}:jobs`)

--- a/vsm-app/pages/api/value-set-packages/[id]/release.ts
+++ b/vsm-app/pages/api/value-set-packages/[id]/release.ts
@@ -3,17 +3,24 @@ import handler from '@/helpers/server/handler'
 import FhirClient from '@/backend/clients/FhirCdrClient'
 import Logger from '@/helpers/server/logger'
 import { is } from '@/helpers/is'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
+import { JOB_TYPE } from '@/constants'
+import { DEFAULT_JOB_CONFIG } from '@/config'
+import Cache from '@/cache'
+import { VSMSession } from '@/helpers/rolesHelper'
 
 /**
- * Release a VSP (draft → active)
- * VSPs use direct status updates, not $release operation
+ * Release a VSP via async $release-manifest operation
  */
 const releaseVSP = async (
   req: NextApiRequest,
-  res: NextApiResponse<{ message: string } | { error: string }>
+  res: NextApiResponse,
+  session: VSMSession
 ): Promise<void> => {
   try {
     const vspId = req.query.id as string
+    const { latestFromTxServer = false } = req.body || {}
+    const userId = session.user.id
 
     // Read the current VSP
     const vsp = (await FhirClient.getInstance().read({
@@ -31,25 +38,26 @@ const releaseVSP = async (
       return res.status(400).json({ error: `Cannot release VSP with status '${vsp.status}'. Only draft VSPs can be released.` })
     }
 
-    // Update status to active
-    vsp.status = 'active'
+    // Queue the release job
+    const job = await VSPReleaseQueue.add(
+      { vspId, latestFromTxServer, userId },
+      DEFAULT_JOB_CONFIG
+    )
 
-    // Set date to now (release date)
-    vsp.date = new Date().toISOString()
-
-    // Update the VSP
-    await FhirClient.getInstance().update({
-      resourceType: 'Library',
-      id: vspId,
-      body: vsp
+    // Track in cache
+    await Cache.setNewJob({
+      userId,
+      jobId: job.id.toString(),
+      type: JOB_TYPE.RELEASE,
+      metadata: JSON.stringify({ programId: vspId, programTitle: vsp.title })
     })
 
-    Logger.getLogger().info(`VSP ${vspId} released (draft → active)`)
-    res.status(200).send({ message: `VSP ${vspId} released successfully` })
+    Logger.getLogger().info(`VSP ${vspId} release job queued with ID: ${job.id}`)
+    return res.status(200).json(job)
   } catch (error: any) {
-    Logger.getLogger().error('Error releasing VSP:', error)
+    Logger.getLogger().error('Error queuing VSP release:', error)
     const diagnostics = error?.response?.data?.issue?.[0]?.diagnostics
-    return res.status(500).json({ error: diagnostics || error?.message || 'Failed to release VSP' })
+    return res.status(500).json({ error: diagnostics || error?.message || 'Failed to queue VSP release' })
   }
 }
 

--- a/vsm-app/tests/api/jobs/[id].spec.ts
+++ b/vsm-app/tests/api/jobs/[id].spec.ts
@@ -30,7 +30,16 @@ jest.mock('../../../worker/DependencyQueue', () => ({
 jest.mock('../../../worker/VSPPackageQueue', () => ({
   __esModule: true,
   default: {
-    process: jest.fn()
+    process: jest.fn(),
+    getJob: jest.fn()
+  }
+}))
+
+jest.mock('../../../worker/VSPReleaseQueue', () => ({
+  __esModule: true,
+  default: {
+    process: jest.fn(),
+    getJob: jest.fn()
   }
 }))
 

--- a/vsm-app/tests/api/jobs/[id]/cancel.spec.ts
+++ b/vsm-app/tests/api/jobs/[id]/cancel.spec.ts
@@ -32,6 +32,10 @@ jest.mock('../../../../worker/ProgramReleaseQueue', () => ({
   __esModule: true,
   default: { getJob: jest.fn() }
 }))
+jest.mock('../../../../worker/VSPReleaseQueue', () => ({
+  __esModule: true,
+  default: { getJob: jest.fn() }
+}))
 jest.mock('../../../../worker/ChangeLogQueue', () => ({
   __esModule: true,
   default: { getJob: jest.fn() }

--- a/vsm-app/tests/api/jobs/[id]/result.spec.ts
+++ b/vsm-app/tests/api/jobs/[id]/result.spec.ts
@@ -36,6 +36,14 @@ jest.mock('../../../../worker/VSPDiffQueue', () => ({
   __esModule: true,
   default: { getJob: jest.fn() }
 }))
+jest.mock('../../../../worker/ProgramReleaseQueue', () => ({
+  __esModule: true,
+  default: { getJob: jest.fn() }
+}))
+jest.mock('../../../../worker/VSPReleaseQueue', () => ({
+  __esModule: true,
+  default: { getJob: jest.fn() }
+}))
 
 import Cache from '@/cache'
 import DependencyQueue from '@/worker/DependencyQueue'

--- a/vsm-app/tests/api/jobs/index.spec.ts
+++ b/vsm-app/tests/api/jobs/index.spec.ts
@@ -4,6 +4,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import PackageQueue from '@/worker/PackageQueue'
 import ChangeLogQueue from '@/worker/ChangeLogQueue'
 import ProgramReleaseQueue from '@/worker/ProgramReleaseQueue'
+import VSPReleaseQueue from '@/worker/VSPReleaseQueue'
 import VSPDiffQueue from '@/worker/VSPDiffQueue'
 import VSPPackageQueue from '@/worker/VSPPackageQueue'
 
@@ -62,6 +63,14 @@ jest.mock('../../../worker/VSPPackageQueue', () => ({
   }
 }))
 
+jest.mock('../../../worker/VSPReleaseQueue', () => ({
+  __esModule: true,
+  default: {
+    process: jest.fn(),
+    getJob: jest.fn()
+  }
+}))
+
 import Cache from '@/cache'
 
 
@@ -107,7 +116,8 @@ describe('/api/jobs', () => {
     ProgramReleaseQueue.getJob = jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() }))
     VSPDiffQueue.getJob = jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() }))
     VSPPackageQueue.getJob = jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() }))
-  
+    VSPReleaseQueue.getJob = jest.fn().mockReturnValue(Promise.resolve({ remove: jest.fn() }))
+
     await handler(req, res)
 
     expect(res._getStatusCode()).toBe(200)

--- a/vsm-app/tests/api/value-set-packages/[id]/lifecycle.spec.ts
+++ b/vsm-app/tests/api/value-set-packages/[id]/lifecycle.spec.ts
@@ -8,10 +8,25 @@ import deleteHandler from '@/pages/api/value-set-packages/[id]/delete'
 jest.mock('next-auth', () => jest.fn())
 jest.mock('next-auth/next', () => ({
   getServerSession: jest.fn().mockImplementation(() => ({
-    user: { roles: ['admin'], email: 'superman@gotham.com' }
+    user: { id: 'user-123', roles: ['admin'], email: 'superman@gotham.com' }
   }))
 }))
 jest.mock('fhir-kit-client')
+
+jest.mock('../../../../worker/VSPReleaseQueue', () => ({
+  __esModule: true,
+  default: {
+    add: jest.fn().mockResolvedValue({ id: 'job-123' })
+  }
+}))
+
+jest.mock('../../../../cache', () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(),
+    setNewJob: jest.fn().mockResolvedValue(undefined)
+  }
+}))
 
 const makeVSPResource = (overrides: any = {}): fhir4.Library => ({
   resourceType: 'Library',
@@ -31,10 +46,9 @@ const makeVSPResource = (overrides: any = {}): fhir4.Library => ({
 
 describe('VSP Lifecycle Operations', () => {
   describe('POST /api/value-set-packages/[id]/release', () => {
-    test('releases a draft VSP (draft → active)', async () => {
+    test('queues an async release job for a draft VSP', async () => {
       const vsp = makeVSPResource({ status: 'draft' })
       FhirClient.getInstance().read = jest.fn().mockResolvedValue(vsp)
-      FhirClient.getInstance().update = jest.fn().mockResolvedValue({ ...vsp, status: 'active' })
 
       const { req, res } = createMocks({
         method: 'POST',
@@ -44,15 +58,9 @@ describe('VSP Lifecycle Operations', () => {
       await releaseHandler(req, res)
       expect(res._getStatusCode()).toBe(200)
 
-      const data = res._getData()
-      expect(data.message).toContain('released')
-
-      // Verify status was set to active
-      expect(FhirClient.getInstance().update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: expect.objectContaining({ status: 'active' })
-        })
-      )
+      const data = JSON.parse(res._getData())
+      // Returns a job object, not a sync message
+      expect(data).toHaveProperty('id', 'job-123')
     })
 
     test('returns 400 when trying to release an active VSP', async () => {
@@ -101,27 +109,6 @@ describe('VSP Lifecycle Operations', () => {
 
       await releaseHandler(req, res)
       expect(res._getStatusCode()).toBe(400)
-    })
-
-    test('sets release date on the VSP', async () => {
-      const vsp = makeVSPResource({ status: 'draft' })
-      FhirClient.getInstance().read = jest.fn().mockResolvedValue(vsp)
-      FhirClient.getInstance().update = jest.fn().mockResolvedValue({ ...vsp, status: 'active' })
-
-      const { req, res } = createMocks({
-        method: 'POST',
-        query: { id: 'test-vsp-2026-01' }
-      })
-
-      await releaseHandler(req, res)
-
-      expect(FhirClient.getInstance().update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: expect.objectContaining({
-            date: expect.any(String)
-          })
-        })
-      )
     })
 
     test('returns 500 on FHIR error', async () => {

--- a/vsm-app/worker/VSPReleaseQueue.ts
+++ b/vsm-app/worker/VSPReleaseQueue.ts
@@ -1,0 +1,201 @@
+import Queue from 'bull'
+import { Agent, fetch as f } from 'undici'
+import { QUEUE_OPTIONS } from '@/config'
+import FhirClient from '@/backend/clients/FhirCdrClient'
+import Cache from '@/cache'
+import { logSimpleError } from '@/helpers/server/simpleHapiError'
+import { tsCredentialService } from '@/backend/services/TsCredentialService'
+import Logger from '@/helpers/server/logger'
+import { JOB_STATUS } from '@/constants'
+
+const VSPReleaseQueue = new Queue('releaseVSP', QUEUE_OPTIONS)
+
+type VSPReleaseQueueJobData = {
+  vspId: string
+  latestFromTxServer: boolean
+  userId: string
+}
+
+VSPReleaseQueue.process(async function (job: Queue.Job<VSPReleaseQueueJobData>, done) {
+  const { vspId, latestFromTxServer, userId } = job.data
+  Logger.getLogger().info('Begin Release Job for VSP Id: ' + vspId)
+
+  const cache = await Cache.getInstance()
+  const cacheKey = `user:${userId}:job:${job.id}`
+
+  try {
+
+  let vsp: fhir4.Library | undefined
+  try {
+    vsp = (await FhirClient.getInstance().read({
+      resourceType: 'Library',
+      id: vspId
+    })) as fhir4.Library
+  } catch (e) {
+    logSimpleError(e)
+  }
+  if (vsp == null) {
+    const error = 'Error encountered fetching Library for release'
+    await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
+    done(null, { error })
+    return
+  }
+
+  // $release requires Library.date (last modified date) and approvalDate to be set
+  const today = new Date().toISOString().split('T')[0]
+  if (!vsp.date || !vsp.approvalDate) {
+    if (!vsp.date) vsp.date = today
+    if (!vsp.approvalDate) vsp.approvalDate = today
+    try {
+      await FhirClient.getInstance().update({
+        resourceType: 'Library',
+        id: vspId,
+        body: vsp
+      })
+      Logger.getLogger().info(`Set date and approvalDate on VSP ${vspId} before release`)
+    } catch (e) {
+      logSimpleError(e)
+      const error = 'Error encountered setting dates on Library before release'
+      await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
+      done(null, { error })
+      return
+    }
+  }
+
+  const releasePayload: fhir4.Parameters = {
+    resourceType: 'Parameters',
+    parameter: [
+      {
+        name: 'version',
+        valueString: vsp.version!
+      },
+      {
+        name: 'versionBehavior',
+        valueCode: 'force'
+      },
+      {
+        name: 'latestFromTxServer',
+        valueBoolean: true
+      }
+    ]
+  }
+
+  // Add terminology endpoint with Basic auth header if VSAC credentials are available
+  try {
+    const vsCreds = await tsCredentialService.getVsacCredentials(userId)
+    const basicAuth = Buffer.from(`${vsCreds.username}:${vsCreds.password}`).toString('base64')
+    releasePayload.parameter!.push({
+      name: 'terminologyEndpoint',
+      resource: {
+        resourceType: 'Endpoint',
+        status: 'active',
+        connectionType: {
+          system: 'http://hl7.org/fhir/ValueSet/endpoint-connection-type',
+          code: 'hl7-fhir-rest'
+        },
+        header: [`Authorization: Basic ${basicAuth}`],
+        address: process.env.NEXT_PUBLIC_VSAC_BASE_URL || 'https://cts.nlm.nih.gov/fhir',
+        payloadType: [{
+          coding: [{
+            system: 'http://hl7.org/fhir/ValueSet/endpoint-payload-type',
+            code: 'any'
+          }]
+        }]
+      } as fhir4.Endpoint
+    })
+  } catch {
+    // No credentials stored — proceed without terminology endpoint
+    Logger.getLogger().info(`No VSAC credentials found for user ${userId}, proceeding without terminologyEndpoint`)
+  }
+
+  const url = `${FhirClient.getInstance().baseUrl}/Library/${vspId}/$release-manifest`
+  Logger.getLogger().info('Preparing for release of VSP id: ' + vspId)
+
+  let response = await f(url, {
+    body: JSON.stringify(releasePayload),
+    method: 'POST',
+    dispatcher: new Agent({
+      connectTimeout: 24 * 60 * 60 * 1000,
+      headersTimeout: 24 * 60 * 60 * 1000,
+      keepAliveTimeout: 24 * 60 * 60 * 1000,
+      keepAliveMaxTimeout: 24 * 60 * 60 * 1000
+    }),
+    // @ts-ignore
+    headers: {
+      ...FhirClient.getInstance().customHeaders,
+      'Content-Type': 'application/fhir+json'
+    }
+  })
+
+  Logger.getLogger().info(`$release-manifest responded with status: ${response.status}`)
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    const error = 'Something went wrong with the release: ' + errorText
+    Logger.getLogger().error(error)
+    await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
+    done(null, { error })
+  } else {
+    // Parse the response Library and update the VSP's expansion parameters
+    try {
+      const result = await response.json() as fhir4.Library
+      const expansionParams = result?.contained?.find(
+        (r) => r.resourceType === 'Parameters' && r.id === 'expansion-parameters'
+      ) as fhir4.Parameters | undefined
+
+      if (expansionParams) {
+        // Re-read the VSP to get the latest version (may have been updated by date-setting above)
+        const currentVsp = (await FhirClient.getInstance().read({
+          resourceType: 'Library',
+          id: vspId
+        })) as fhir4.Library
+
+        // Replace the contained expansion-parameters-vsp with the resolved one
+        expansionParams.id = 'expansion-parameters-vsp'
+        const filteredContained = currentVsp.contained?.filter((r) => r.id !== 'expansion-parameters-vsp') || []
+        filteredContained.push(expansionParams)
+        currentVsp.contained = filteredContained
+
+        // Ensure the extension reference exists
+        const hasExpansionExt = currentVsp.extension?.some(
+          (ext) => ext.url === 'http://hl7.org/fhir/StructureDefinition/cqf-expansionParameters'
+        )
+        if (!hasExpansionExt) {
+          currentVsp.extension = [
+            ...(currentVsp.extension || []),
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/cqf-expansionParameters',
+              valueReference: { reference: '#expansion-parameters-vsp' }
+            }
+          ]
+        }
+
+        await FhirClient.getInstance().update({
+          resourceType: 'Library',
+          id: vspId,
+          body: currentVsp
+        })
+        Logger.getLogger().info(`Updated VSP ${vspId} manifest with resolved expansion parameters`)
+      } else {
+        Logger.getLogger().warn(`$release-manifest response did not contain expansion-parameters for VSP ${vspId}`)
+      }
+    } catch (e) {
+      logSimpleError(e)
+      Logger.getLogger().error(`Failed to update VSP ${vspId} manifest with release-manifest results`)
+      // Don't fail the job — the release itself succeeded
+    }
+
+    Logger.getLogger().info('Finished')
+    await cache.hset(cacheKey, 'status', JOB_STATUS.COMPLETED)
+    return done(null, { response: "Finished" })
+  }
+
+  } catch (e: any) {
+    const error = e?.message || 'Unknown error during release'
+    Logger.getLogger().error('Release job failed with unhandled error: ' + error)
+    await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
+    done(null, { error })
+  }
+})
+
+export default VSPReleaseQueue


### PR DESCRIPTION
Summary

  - Replaces the synchronous VSP release (direct status = 'active' PUT) with an async Bull worker that calls the FHIR $release-manifest operation
  - The worker sets Library.date and Library.approvalDate if missing before calling $release-manifest, and updates the VSP's expansion parameters with the resolved versions from the response
  - The frontend now polls via NotificationStore for job completion, showing an "in progress" toast and success/failure notifications
  - Uses Basic auth Authorization header for the VSAC terminology endpoint (not the extension-based format)
  - Wires VSPReleaseQueue into all job API endpoints (result, cancel, status, cleanup)

  Test plan

  - Create a draft VSP and trigger release from the VSP details page
  - Confirm "VSP release in progress" toast appears and the notification bell shows a pending release
  - Confirm server logs show POST /Library/{vspId}/$release-manifest with version, versionBehavior, latestFromTxServer, and
  terminologyEndpoint parameters
  - On success, confirm notification updates to complete, page refreshes to show active VSP, and manifest contains resolved expansion parameters
  - Test cancellation via the notification panel
  - Test failure case (e.g., missing VSAC credentials) — confirm error notification appears
  - Run npx jest --no-coverage