### PR TITLE
lazy-init Logger so Bull workers don't crash at boot

### DIFF
--- a/vsm-app/helpers/server/logger.ts
+++ b/vsm-app/helpers/server/logger.ts
@@ -24,6 +24,9 @@ class Logger {
   }
 
   static getLogger() {
+    if (!Logger.instance) {
+      Logger.initLogger()
+    }
     return Logger.instance
   }
 


### PR DESCRIPTION
- Logger.getLogger() returned undefined until the first HTTP request triggered Logger.initLogger() from handler.ts. In Next.js production, API route modules (and their worker/*Queue.ts imports) load at server boot, which registers Bull processors and starts dispatching any jobs already waiting in Redis. If Bull dispatched a job before any HTTP request had run, the worker's first Logger.getLogger().info(...) call crashed with TypeError: Cannot read properties of undefined (reading 'info'), producing an unhandled rejection that wedged the consumer and left the job stuck in waiting.
  - This surfaced as the Fetch Dependencies flow returning JSON.parse: unexpected character at line 1 column 1 on the client: the wedged worker prevented job completion, the gateway timed out, and the browser tried to parse an HTML error page as JSON.
  - Fix: Logger.getLogger() now lazy-calls Logger.initLogger() if Logger.instance is unset, so worker callbacks dispatched before any HTTP request initialize the logger on first use instead of crashing.