### PR TITLE
Warn on VSP export/release when manifest has unversioned refs

### DIFF
--- a/vsm-app/components/VSPDetails/index.tsx
+++ b/vsm-app/components/VSPDetails/index.tsx
@@ -6,10 +6,11 @@ import { useSession } from 'next-auth/react'
 import { allowEditing, allowRelease, allowWithdraw, allowRetire, allowDelete, can, VSMSession } from '@/helpers/rolesHelper'
 import { StatusChip } from '@/components/data-display/Chips'
 import type { LibraryServerSideProps } from '@/utils/getLibraryServerSideProp'
-import { getVSPManifestVersions } from '@/helpers/valueSetHelpers'
+import { getVSPManifestVersions, findUnversionedManifestRefs } from '@/helpers/valueSetHelpers'
 import { LoadingModal } from '@/components/modals/LoadingModal'
 import { ErrorMessage } from '@/components/ErrorMessage'
 import { ExportPackageDetailsModal } from '@/components/modals/PackageDetailsModal'
+import ConfirmUnversionedRefsModal from '@/components/modals/ConfirmUnversionedRefsModal'
 import { toast } from 'react-toastify'
 import { debounce } from 'lodash'
 import styled from 'styled-components'
@@ -63,6 +64,7 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
   // Release state
   const [releaseLoading, setReleaseLoading] = useState(false)
   const [releaseModalOpen, setReleaseModalOpen] = useState(false)
+  const [releaseUnversionedConfirmOpen, setReleaseUnversionedConfirmOpen] = useState(false)
 
   // Withdraw state
   const [withdrawLoading, setWithdrawLoading] = useState(false)
@@ -104,6 +106,18 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
 
   const { id = '', status, experimental } = currentVSP
   const manifestData = getVSPManifestVersions(currentVSP)
+  const unversionedReleaseRefs = findUnversionedManifestRefs(currentVSP)
+  const hasUnversionedReleaseRefs =
+    unversionedReleaseRefs.codeSystems.length + unversionedReleaseRefs.valueSets.length > 0
+
+  const startRelease = () => {
+    setError({})
+    if (hasUnversionedReleaseRefs) {
+      setReleaseUnversionedConfirmOpen(true)
+    } else {
+      setReleaseModalOpen(true)
+    }
+  }
 
   // Get IG reference from relatedArtifact
   const igReference = currentVSP.relatedArtifact?.find((ra) => ra.type === 'composed-of')?.resource || 'N/A'
@@ -253,6 +267,17 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
   return (
     <Col>
       {/* Modals */}
+      <ConfirmUnversionedRefsModal
+        isOpen={releaseUnversionedConfirmOpen}
+        action="release"
+        codeSystems={unversionedReleaseRefs.codeSystems}
+        valueSets={unversionedReleaseRefs.valueSets}
+        onCancel={() => setReleaseUnversionedConfirmOpen(false)}
+        onConfirm={() => {
+          setReleaseUnversionedConfirmOpen(false)
+          setReleaseModalOpen(true)
+        }}
+      />
       {releaseModalOpen && (
         <LoadingModal
           actionType="release"
@@ -358,10 +383,7 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
                 <Button
                   variant="contained"
                   disabled={currentVSP.status !== 'draft'}
-                  onClick={() => {
-                    setError({})
-                    setReleaseModalOpen(true)
-                  }}
+                  onClick={startRelease}
                   style={{
                     backgroundColor: currentVSP.status === 'draft' ? 'var(--theme-400)' : undefined
                   }}

--- a/vsm-app/components/ValueSetPackage/ValueSetPackagesTab.tsx
+++ b/vsm-app/components/ValueSetPackage/ValueSetPackagesTab.tsx
@@ -21,6 +21,8 @@ import { toast } from 'react-toastify'
 import { CreateVSPModal } from '@/components/modals/CreateVSPModal'
 import { CreateVSPRequest } from '@/types/vspTypes'
 import { apiFetch } from '@/utils'
+import { findUnversionedManifestRefs } from '@/helpers/valueSetHelpers'
+import ConfirmUnversionedRefsModal from '@/components/modals/ConfirmUnversionedRefsModal'
 
 const Col = styled.div`
   display: flex;
@@ -70,7 +72,7 @@ const generateBlockedReason = (vsp: fhir4.Library, actionType: 'release' | 'with
 interface ExpandableRowProps {
   data: fhir4.Library
   session: VSMSession
-  handleClickRelease: (vspId: string | undefined) => void
+  handleClickRelease: (row: fhir4.Library) => void
   handleClickWithdraw: (vspId: string | undefined) => void
   handleClickRetire: (vspId: string | undefined) => void
   handleClickDelete: (vspId: string | undefined) => void
@@ -116,7 +118,7 @@ const ExpandableRowComponent = ({
                 disabled={row.status !== 'draft'}
                 onClick={() => {
                   setError({})
-                  handleClickRelease(row?.id)
+                  handleClickRelease(row)
                 }}
               >
                 Release
@@ -214,6 +216,8 @@ const ValueSetPackagesTab: NextPage = () => {
   const [releaseLoading, setReleaseLoading] = useState(false)
   const [releaseModalOpen, setReleaseModalOpen] = useState(false)
   const [vspIdToRelease, setVspIdToRelease] = useState('')
+  const [releaseUnversionedConfirmOpen, setReleaseUnversionedConfirmOpen] = useState(false)
+  const [releaseUnversionedRefs, setReleaseUnversionedRefs] = useState<{ codeSystems: string[]; valueSets: string[] }>({ codeSystems: [], valueSets: [] })
 
   // retire state
   const [retireLoading, setRetireLoading] = useState(false)
@@ -320,10 +324,16 @@ const ValueSetPackagesTab: NextPage = () => {
 
   const handlePageChange = (newPage: number) => setPagination({ ...pagination, page: newPage })
 
-  const handleClickRelease = (vspId: string | undefined) => {
-    if (!vspId) return
-    setVspIdToRelease(vspId)
-    setReleaseModalOpen(true)
+  const handleClickRelease = (row: fhir4.Library) => {
+    if (!row?.id) return
+    setVspIdToRelease(row.id)
+    const refs = findUnversionedManifestRefs(row)
+    if (refs.codeSystems.length + refs.valueSets.length > 0) {
+      setReleaseUnversionedRefs(refs)
+      setReleaseUnversionedConfirmOpen(true)
+    } else {
+      setReleaseModalOpen(true)
+    }
   }
 
   const handleClickWithdraw = (vspId: string | undefined) => {
@@ -637,6 +647,20 @@ const ValueSetPackagesTab: NextPage = () => {
 
   return (
     <Col>
+      <ConfirmUnversionedRefsModal
+        isOpen={releaseUnversionedConfirmOpen}
+        action="release"
+        codeSystems={releaseUnversionedRefs.codeSystems}
+        valueSets={releaseUnversionedRefs.valueSets}
+        onCancel={() => {
+          setReleaseUnversionedConfirmOpen(false)
+          setVspIdToRelease('')
+        }}
+        onConfirm={() => {
+          setReleaseUnversionedConfirmOpen(false)
+          setReleaseModalOpen(true)
+        }}
+      />
       {releaseModalOpen && (
         <LoadingModal
           actionType="release"

--- a/vsm-app/components/modals/ConfirmUnversionedRefsModal.tsx
+++ b/vsm-app/components/modals/ConfirmUnversionedRefsModal.tsx
@@ -31,14 +31,14 @@ const ACTION_COPY: Record<ConfirmUnversionedRefsAction, { title: string; intro: 
   export: {
     title: 'Unversioned manifest references',
     intro:
-      'This VSP has manifest entries without a pinned version. Unversioned entries are not applied during $package and may produce inconsistent results. You can proceed, but the unversioned entries below will not influence the exported bundle.',
-    confirmLabel: 'Export anyway'
+      "The manifest has the following unversioned references. The versions used in building the expansions in the resulting package will be selected by the terminology server performing the expansions. This may be unavoidable for some code systems that don't specify versioning information, such as USPS state abbreviations.",
+    confirmLabel: 'Continue export'
   },
   release: {
     title: 'Unversioned manifest references',
     intro:
-      'This VSP has manifest entries without a pinned version. Unversioned entries are not applied during $release-manifest. You can proceed, but the unversioned entries below will not be pinned in the released VSP.',
-    confirmLabel: 'Release anyway'
+      'The manifest has the following unversioned references. The release process will attempt to pin these references to the latest version available from the terminology server.',
+    confirmLabel: 'Continue release'
   }
 }
 
@@ -79,7 +79,7 @@ const ConfirmUnversionedRefsModal = ({
       <ModalContent style={{ minWidth: '320px' }}>
         <DialogTitle sx={{ textAlign: 'left' }}>{copy.title}</DialogTitle>
         <DialogContent>
-          <Alert severity="warning" sx={{ mb: 1 }}>
+          <Alert severity="info" sx={{ mb: 1 }}>
             <DialogContentText sx={{ color: 'inherit' }}>{copy.intro}</DialogContentText>
           </Alert>
           <Section heading="CodeSystems" items={codeSystems} />

--- a/vsm-app/components/modals/ConfirmUnversionedRefsModal.tsx
+++ b/vsm-app/components/modals/ConfirmUnversionedRefsModal.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  Typography
+} from '@mui/material'
+import { ModalContent } from '@/styles/modal'
+
+export type ConfirmUnversionedRefsAction = 'export' | 'release'
+
+interface Props {
+  isOpen: boolean
+  action: ConfirmUnversionedRefsAction
+  codeSystems: string[]
+  valueSets: string[]
+  onCancel: () => void
+  onConfirm: () => void
+  confirmLoading?: boolean
+}
+
+const ACTION_COPY: Record<ConfirmUnversionedRefsAction, { title: string; intro: string; confirmLabel: string }> = {
+  export: {
+    title: 'Unversioned manifest references',
+    intro:
+      'This VSP has manifest entries without a pinned version. Unversioned entries are not applied during $package and may produce inconsistent results. You can proceed, but the unversioned entries below will not influence the exported bundle.',
+    confirmLabel: 'Export anyway'
+  },
+  release: {
+    title: 'Unversioned manifest references',
+    intro:
+      'This VSP has manifest entries without a pinned version. Unversioned entries are not applied during $release-manifest. You can proceed, but the unversioned entries below will not be pinned in the released VSP.',
+    confirmLabel: 'Release anyway'
+  }
+}
+
+const Section = ({ heading, items }: { heading: string; items: string[] }) => {
+  if (items.length === 0) return null
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        {heading} ({items.length})
+      </Typography>
+      <List dense disablePadding sx={{ maxHeight: 180, overflow: 'auto' }}>
+        {items.map((canonical) => (
+          <ListItem key={canonical} disableGutters sx={{ py: 0 }}>
+            <ListItemText
+              primaryTypographyProps={{ variant: 'body2', sx: { wordBreak: 'break-all' } }}
+              primary={canonical}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+}
+
+const ConfirmUnversionedRefsModal = ({
+  isOpen,
+  action,
+  codeSystems,
+  valueSets,
+  onCancel,
+  onConfirm,
+  confirmLoading = false
+}: Props) => {
+  const copy = ACTION_COPY[action]
+
+  return (
+    <Dialog open={isOpen} onClose={onCancel} maxWidth="sm" fullWidth>
+      <ModalContent style={{ minWidth: '320px' }}>
+        <DialogTitle sx={{ textAlign: 'left' }}>{copy.title}</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 1 }}>
+            <DialogContentText sx={{ color: 'inherit' }}>{copy.intro}</DialogContentText>
+          </Alert>
+          <Section heading="CodeSystems" items={codeSystems} />
+          <Section heading="ValueSets" items={valueSets} />
+        </DialogContent>
+        <DialogActions>
+          <Button disabled={confirmLoading} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button disabled={confirmLoading} variant="contained" onClick={onConfirm}>
+            {copy.confirmLabel}
+          </Button>
+        </DialogActions>
+      </ModalContent>
+    </Dialog>
+  )
+}
+
+export default ConfirmUnversionedRefsModal

--- a/vsm-app/components/modals/PackageDetailsModal.tsx
+++ b/vsm-app/components/modals/PackageDetailsModal.tsx
@@ -29,6 +29,8 @@ import { JOB_TYPE } from '@/constants'
 import dayjs from 'dayjs';
 import { ExportJobMetadata } from '@/types/jobTypes'
 import { apiFetch } from '@/utils'
+import { findUnversionedManifestRefs } from '@/helpers/valueSetHelpers'
+import ConfirmUnversionedRefsModal from '@/components/modals/ConfirmUnversionedRefsModal'
 
 interface ModalInfo {
   isOpen: boolean
@@ -96,6 +98,12 @@ const ExportPackageDetailsModal = ({ isOpen, toggleModalOpen, program, setExport
   const [fileUploadContent, setFileUploadContent] = useState<undefined | { fileName: string; content: fhir4.PlanDefinition }>(undefined)
   const [targetVersion, setTargetVersion] = useState<string>('')
   const [inputError, setInputError] = useState<boolean>(false)
+  const [unversionedConfirmOpen, setUnversionedConfirmOpen] = useState(false)
+
+  const unversionedRefs = resourceType === 'vsp'
+    ? findUnversionedManifestRefs(program)
+    : { codeSystems: [], valueSets: [] }
+  const hasUnversionedRefs = unversionedRefs.codeSystems.length + unversionedRefs.valueSets.length > 0
 
   const handleResetState = () => {
     setFileType('json')
@@ -161,6 +169,14 @@ const ExportPackageDetailsModal = ({ isOpen, toggleModalOpen, program, setExport
   }
 
   const handleClickExport = async () => {
+    if (hasUnversionedRefs) {
+      setUnversionedConfirmOpen(true)
+      return
+    }
+    await runExport()
+  }
+
+  const runExport = async () => {
     setDownloadLoading(true)
 
     try {
@@ -228,6 +244,19 @@ const ExportPackageDetailsModal = ({ isOpen, toggleModalOpen, program, setExport
   }
 
   return (
+    <>
+    <ConfirmUnversionedRefsModal
+      isOpen={unversionedConfirmOpen}
+      action="export"
+      codeSystems={unversionedRefs.codeSystems}
+      valueSets={unversionedRefs.valueSets}
+      confirmLoading={downloadLoading}
+      onCancel={() => setUnversionedConfirmOpen(false)}
+      onConfirm={async () => {
+        setUnversionedConfirmOpen(false)
+        await runExport()
+      }}
+    />
     <Dialog open={isOpen} onClose={handleResetState}>
       <ModalContent style={{ minWidth: '300px' }}>
         <DialogTitle sx={{ textAlign: 'left' }}>Export Options</DialogTitle>
@@ -268,6 +297,7 @@ const ExportPackageDetailsModal = ({ isOpen, toggleModalOpen, program, setExport
         </DialogActions>
       </ModalContent>
     </Dialog>
+    </>
   )
 }
 

--- a/vsm-app/helpers/valueSetHelpers.spec.ts
+++ b/vsm-app/helpers/valueSetHelpers.spec.ts
@@ -12,7 +12,8 @@ import {
   organizeValueSetDefinitionData,
   setExpansionParametersForVSP,
   getVSPManifestVersions,
-  getProgramManifestVersions
+  getProgramManifestVersions,
+  findUnversionedManifestRefs
 } from './valueSetHelpers'
 import { uniq } from 'lodash'
 import { DeleteData, UpdateData } from '@/pages/api/codesystem/provisional';
@@ -1026,6 +1027,187 @@ describe('VSP Manifest Functions', () => {
 
       const result = getVSPManifestVersions(library)
       expect(result.codeSystems['http://loinc.org']).toEqual(['2.74'])
+    })
+  })
+
+  describe('findUnversionedManifestRefs', () => {
+    it('returns empty arrays when the library has no contained Parameters', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] }
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({ codeSystems: [], valueSets: [] })
+    })
+
+    it('returns empty arrays when every entry has a version pin', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueString: 'http://loinc.org|2.74' },
+            { name: 'valueset-version', valueString: 'http://hl7.org/fhir/ValueSet/gender|4.0.1' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({ codeSystems: [], valueSets: [] })
+    })
+
+    it('flags entries with no pipe at all (canonical only)', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueString: 'http://loinc.org' },
+            { name: 'valueset-version', valueString: 'http://hl7.org/fhir/ValueSet/gender' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({
+        codeSystems: ['http://loinc.org'],
+        valueSets: ['http://hl7.org/fhir/ValueSet/gender']
+      })
+    })
+
+    it('flags entries with an empty version segment after the pipe', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueString: 'http://loinc.org|' },
+            { name: 'valueset-version', valueString: 'http://hl7.org/fhir/ValueSet/gender|   ' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({
+        codeSystems: ['http://loinc.org'],
+        valueSets: ['http://hl7.org/fhir/ValueSet/gender']
+      })
+    })
+
+    it('splits versioned and unversioned entries correctly when mixed', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueString: 'http://snomed.info/sct|20240301' },
+            { name: 'system-version', valueString: 'http://loinc.org' },
+            { name: 'valueset-version', valueString: 'http://hl7.org/fhir/ValueSet/gender|4.0.1' },
+            { name: 'valueset-version', valueString: 'http://example.org/ValueSet/x' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({
+        codeSystems: ['http://loinc.org'],
+        valueSets: ['http://example.org/ValueSet/x']
+      })
+    })
+
+    it('deduplicates repeated unversioned canonicals', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueString: 'http://loinc.org' },
+            { name: 'system-version', valueString: 'http://loinc.org|' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library).codeSystems).toEqual(['http://loinc.org'])
+    })
+
+    it('reads valueCanonical and valueUri in addition to valueString', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'system-version', valueCanonical: 'http://canonical.example/cs' },
+            { name: 'valueset-version', valueUri: 'http://uri.example/vs' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({
+        codeSystems: ['http://canonical.example/cs'],
+        valueSets: ['http://uri.example/vs']
+      })
+    })
+
+    it('reads from expansion-parameters-ecr as well', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-program',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-ecr',
+          parameter: [
+            { name: 'system-version', valueString: 'http://loinc.org' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library).codeSystems).toEqual(['http://loinc.org'])
+    })
+
+    it('ignores unrelated parameter names', () => {
+      const library: fhir4.Library = {
+        resourceType: 'Library',
+        id: 'test-vsp',
+        status: 'draft',
+        type: { coding: [{ code: 'asset-collection' }] },
+        contained: [{
+          resourceType: 'Parameters',
+          id: 'expansion-parameters-vsp',
+          parameter: [
+            { name: 'force', valueBoolean: true },
+            { name: 'system-version', valueString: 'http://loinc.org' }
+          ]
+        } as fhir4.Parameters]
+      }
+
+      expect(findUnversionedManifestRefs(library)).toEqual({
+        codeSystems: ['http://loinc.org'],
+        valueSets: []
+      })
     })
   })
 

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -358,6 +358,36 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   return { codeSystems, valueSets }
 }
 
+/**
+ * Returns the canonical URLs in a VSP Library's contained `expansion-parameters-vsp`
+ * (or `expansion-parameters-ecr`) Parameters whose version pin is missing or empty.
+ * An entry is considered unversioned when the value (`valueCanonical`/`valueString`/
+ * `valueUri`) has no `|version` suffix or its version segment is whitespace-only.
+ */
+const findUnversionedManifestRefs = (library: fhir4.Library): { codeSystems: string[]; valueSets: string[] } => {
+  const codeSystems: string[] = []
+  const valueSets: string[] = []
+
+  const parameterResource = library?.contained?.find((r) =>
+    r.id === 'expansion-parameters-vsp' || r.id === 'expansion-parameters-ecr'
+  ) as fhir4.Parameters | undefined
+
+  parameterResource?.parameter?.forEach((p) => {
+    if (p.name !== 'system-version' && p.name !== 'valueset-version') return
+    const raw = p.valueCanonical || p.valueString || p.valueUri || ''
+    const [canonical, version = ''] = decodeURI(raw).split('|')
+    if (!canonical) return
+    if (version.trim() !== '') return
+    if (p.name === 'system-version') {
+      if (!codeSystems.includes(canonical)) codeSystems.push(canonical)
+    } else {
+      if (!valueSets.includes(canonical)) valueSets.push(canonical)
+    }
+  })
+
+  return { codeSystems, valueSets }
+}
+
 // update grouper valueset with proper version
 const updateLeafVsVersion = (vs: fhir4.ValueSet, canonicalToUpdate: string, version: string): fhir4.ValueSet => {
   const vsCopy = cloneDeep(vs)
@@ -739,5 +769,6 @@ export {
   urlWithoutPinnedVersion,
   // VSP-specific manifest functions
   setExpansionParametersForVSP,
-  getVSPManifestVersions
+  getVSPManifestVersions,
+  findUnversionedManifestRefs
 }

--- a/vsm-app/worker/VSPPackageQueue.ts
+++ b/vsm-app/worker/VSPPackageQueue.ts
@@ -201,10 +201,11 @@ VSPPackageQueue.process(async function (job: any, done) {
       method: 'POST',
       body: JSON.stringify(parametersInput),
       dispatcher: new Agent({
-        connectTimeout: 10 * 60 * 1000,  // 10 minutes
-        headersTimeout: 10 * 60 * 1000,
-        keepAliveTimeout: 10 * 60 * 1000,
-        keepAliveMaxTimeout: 10 * 60 * 1000
+        connectTimeout: 60 * 60 * 1000,  // 1 hour
+        headersTimeout: 60 * 60 * 1000,
+        bodyTimeout: 60 * 60 * 1000,
+        keepAliveTimeout: 60 * 60 * 1000,
+        keepAliveMaxTimeout: 60 * 60 * 1000
       }),
       headers: {
         'Content-Type': 'application/fhir+json',


### PR DESCRIPTION
## Summary

  - Adds a confirmation modal that surfaces unversioned manifest references (entries in expansion-parameters-vsp whose valueString/valueCanonical/valueUri has no |version suffix) before a user proceeds with VSP Export or Release. The modal lists the unversioned CodeSystems and ValueSets and explains the terminology server will pick the versions; for Release, it notes the release process will attempt to pin them. Neither path mutates request bodies - the modal is purely a UI gate so users understand what the server-side expansion will and won't do.
  - Adds shared helper findUnversionedManifestRefs(library) in helpers/valueSetHelpers.ts and a shared ConfirmUnversionedRefsModal component, wired into components/modals/PackageDetailsModal.tsx (Export) and both Release entry points (components/VSPDetails/index.tsx, components/ValueSetPackage/ValueSetPackagesTab.tsx).
  - Includes 9 new unit tests for the detection helper covering empty inputs, all-versioned manifests, missing-pipe and empty-version-segment entries, mixed versioned/unversioned splits, dedupe, all three value[x] shapes, the expansion-parameters-ecr backward-compat id, and ignoring unrelated parameter names.
  - Bundles a fix to worker/VSPPackageQueue.ts: adds the previously-missing bodyTimeout on the undici Agent and raises all $package timeouts from 10 min to 1 hour. Without bodyTimeout, undici was using its 300 s default and dropping the connection mid-stream on slow expansions (e.g. US Core 7.0.0), surfacing as ClientAbortException:  Broken pipe on the FHIR server and fetch failed in the worker. Discovered during testing of the warning flow.

## Test plan

  - Open Export Options on a VSP whose manifest contains unversioned entries; confirm the informational modal lists them, "Continue export" proceeds with the existing payload, "Cancel" closes without firing the job.
  - Open Export Options on a VSP with no unversioned entries; confirm the modal does not appear and the existing flow runs unchanged.
  - Click Release on a draft VSP with unversioned entries (both from VSPDetails and from the ValueSetPackages list page); confirm the modal appears first, then on "Continue release" the existing LoadingModal opens. On Cancel, no release modal opens.
  - Click Release on a draft VSP with no unversioned entries; confirm the existing LoadingModal opens directly.
  - Trigger an export against a long-running $package (e.g. US Core 7.0.0); confirm it completes without fetch failed / Broken pipe after ~5 min.
  - npx jest helpers/valueSetHelpers.spec.ts — full suite passes (39 tests).