### PR TITLE
Manual version pinning in edit manifest with unversioned filter

### DIFF
--- a/vsm-app/components/EditManifestDetails/index.tsx
+++ b/vsm-app/components/EditManifestDetails/index.tsx
@@ -10,14 +10,20 @@ import useSWR from 'swr'
 import { fetcher, apiFetch } from '@/utils'
 import { modalStyle } from '@/styles'
 import { SystemSelection, ManifestDataMap, ManifestSystemVersionPair, ManifestUrlNameMap, ManifestData, SelectedManifestDataVersion } from '@/types/manifestTypes'
-import { getProgramManifestVersions, getVSPManifestVersions } from '@/helpers/valueSetHelpers'
+import {
+  getProgramManifestVersions,
+  getVSPManifestVersions,
+  filterToUnversioned,
+  applyVersionUpdate,
+  applyAddManifestEntry
+} from '@/helpers/valueSetHelpers'
 import { customTableStyles } from '@/components/tables/themes'
 import InfoIcon from '@mui/icons-material/Info'
 import Tooltip from '@mui/material/Tooltip'
 import { ErrorMessage } from '@/components/ErrorMessage'
 import LoadingIndicator from '../LoadingIndicator'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
-import { Tab } from '@mui/material'
+import { Tab, FormControlLabel, Switch, TextField, Stack } from '@mui/material'
 import { is } from '@/helpers/is'
 import {
   getIdFromSystem,
@@ -94,13 +100,18 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
   const [systemNamesByUri, setSystemNamesByUri] = useState<ManifestUrlNameMap>({})
   const [pageLoading, setPageLoading] = useState(true)
 
-  // Determine API endpoint based on whether it's a VSP or Program
+  // VSP-only: manual entry + unversioned filter
+  const [addCanonical, setAddCanonical] = useState('')
+  const [addVersion, setAddVersion] = useState('')
+  const [showOnlyUnversioned, setShowOnlyUnversioned] = useState(false)
+
+  // Determine API endpoint based on whether it's a VSP or Program.
+  // VSPs don't need this catalog at all — the dropdown is gone and
+  // ManifestDetailTable does its own fetch for name lookups.
   const programId = program?.id
   let apiEndpoint: string | null = null
-  if (programId) {
-    apiEndpoint = isVSP
-      ? `/api/value-set-packages/${programId}/manifest?resourceType=${resourceType}`
-      : `/api/programs/${programId}/manifest`
+  if (programId && !isVSP) {
+    apiEndpoint = `/api/programs/${programId}/manifest`
   }
 
   const {
@@ -162,7 +173,8 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
         setPageLoading(false)
       }
     }
-    if (program?.id && selectedSystem && !availableVersions[selectedSystem]) {
+    const programIdForFetch = program?.id
+    if (!isVSP && programIdForFetch && selectedSystem && !availableVersions[selectedSystem]) {
       retrieveSelectedSystemVersions()
     }
   }, [selectedSystem, availableVersions, program?.id, isVSP, resourceType])
@@ -170,6 +182,14 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
   const selectOptions = useMemo(() => {
     return systemSelections?.map(({ uri, name }) => ({ value: uri, label: `${name}` }))
   }, [systemSelections])
+
+  // VSP-only: filter the displayed manifest to only unversioned entries when the toggle is on.
+  // Defined above the early returns below so the hook order stays stable across renders.
+  const displayManifestData = useMemo(() => {
+    const active = isVSP && manifestTab === 'valuesets' ? currentSelectedValueSets : currentSelectedData
+    if (!isVSP || !showOnlyUnversioned) return active
+    return filterToUnversioned(active)
+  }, [isVSP, manifestTab, currentSelectedValueSets, currentSelectedData, showOnlyUnversioned])
 
   const deleteFn = ({ system, version }: ManifestSystemVersionPair) => {
     setIsUpdating(true)
@@ -201,11 +221,11 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
     setIsUpdating(false)
   }
 
-  if (isLoading) {
+  if (!isVSP && isLoading) {
     return <LoadingIndicator />
   }
 
-  if (selectOptions.length === 0) {
+  if (!isVSP && selectOptions.length === 0) {
     return (
       <ErrorMessage
         error="No CodeSystem or ValueSet data available from the terminology server. Please check your VSAC credentials in Settings."
@@ -249,6 +269,65 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
   // Get the current manifest data based on active tab (for VSPs)
   const activeManifestData = isVSP && manifestTab === 'valuesets' ? currentSelectedValueSets : currentSelectedData
 
+  // VSP-only: replace an existing version pin in-place (used by inline edit on table rows)
+  const handleUpdateVersion = (system: string, oldVersion: string, newVersion: string) => {
+    setIsUpdating(true)
+    const sourceData = manifestTab === 'valuesets' ? currentSelectedValueSets : currentSelectedData
+    const updated = applyVersionUpdate(sourceData, system, oldVersion, newVersion)
+
+    const dataToSend = {
+      codeSystems: manifestTab === 'codesystems' ? updated : currentSelectedData,
+      valueSets: manifestTab === 'valuesets' ? updated : currentSelectedValueSets
+    }
+
+    updateManifest({
+      programId: program?.id as string,
+      currentSelectedData: dataToSend,
+      setCurrentSelectedData: manifestTab === 'codesystems' ? setCurrentSelectedData : setCurrentSelectedValueSets,
+      setIsUpdating,
+      action: 'add',
+      id: getIdFromSystem(system),
+      version: newVersion,
+      isVSP: true,
+      activeTab: manifestTab
+    })
+  }
+
+  // VSP-only: add a new manifest entry from the free-text canonical + version inputs
+  const handleAddVSP = () => {
+    const canonical = addCanonical.trim()
+    if (!canonical) {
+      toast.error('Canonical URL is required')
+      return
+    }
+    const version = addVersion.trim()
+
+    setIsUpdating(true)
+    const sourceData = manifestTab === 'valuesets' ? currentSelectedValueSets : currentSelectedData
+    const updated = applyAddManifestEntry(sourceData, canonical, version)
+
+    const dataToSend = {
+      codeSystems: manifestTab === 'codesystems' ? updated : currentSelectedData,
+      valueSets: manifestTab === 'valuesets' ? updated : currentSelectedValueSets
+    }
+
+    updateManifest({
+      programId: program?.id as string,
+      currentSelectedData: dataToSend,
+      setCurrentSelectedData: manifestTab === 'codesystems' ? setCurrentSelectedData : setCurrentSelectedValueSets,
+      setIsUpdating,
+      action: 'add',
+      id: getIdFromSystem(canonical),
+      version,
+      isVSP: true,
+      activeTab: manifestTab
+    })
+
+    setAddCanonical('')
+    setAddVersion('')
+  }
+
+
   // Filter out empty (unresolved) and provisional versions — only resolved, non-provisional versions should block adding
   const containsNonProvisionalVersion = activeManifestData[selectedSystem]?.filter((i) => i && !i.toLowerCase().includes('provisional')) || []
   const hasUnresolvedVersion = activeManifestData[selectedSystem]?.some((i) => !i) || false
@@ -258,6 +337,67 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
     : `Version ${containsNonProvisionalVersion[0] || activeManifestData[selectedSystem]} selected for ${getNameByUri(selectedSystem, systemNamesByUri) || selectedSystem}.`
 
   const shouldDisableAddButton = (activeManifestData[selectedSystem] != null && containsNonProvisionalVersion?.length > 0) || isUpdating
+
+  const vspManifestContent = (
+    <>
+      <ManifestDescription context="manifest-page" />
+      <Box sx={{ mt: 3, mb: 2, p: 2, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Add {manifestTab === 'valuesets' ? 'ValueSet' : 'CodeSystem'} version
+        </Typography>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1} alignItems={{ md: 'center' }}>
+          <TextField
+            size="small"
+            label="Canonical URL"
+            placeholder={manifestTab === 'valuesets' ? 'http://hl7.org/fhir/ValueSet/...' : 'http://loinc.org'}
+            value={addCanonical}
+            onChange={(e) => setAddCanonical(e.target.value)}
+            sx={{ flex: 2 }}
+            inputProps={{ 'data-add-canonical': true }}
+          />
+          <TextField
+            size="small"
+            label="Version (optional)"
+            placeholder="e.g. 2.74"
+            value={addVersion}
+            onChange={(e) => setAddVersion(e.target.value)}
+            sx={{ flex: 1 }}
+            inputProps={{ 'data-add-version': true }}
+          />
+          <Button
+            text="Add"
+            disabled={isUpdating || !addCanonical.trim()}
+            loading={isUpdating}
+            onClick={handleAddVSP}
+          />
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+          Leave the version empty to add an unversioned entry — the terminology server will choose the version during expansion.
+        </Typography>
+      </Box>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={showOnlyUnversioned}
+              onChange={(e) => setShowOnlyUnversioned(e.target.checked)}
+              inputProps={{ 'aria-label': 'Show only unversioned entries' }}
+            />
+          }
+          label="Show only unversioned"
+        />
+      </Stack>
+      <ManifestDetailTable
+        programId={program?.id!}
+        manifestData={displayManifestData}
+        deleteFn={deleteFn}
+        resourceType="vsp"
+        unversionedSeverity="info"
+        onUpdateVersion={handleUpdateVersion}
+      />
+    </>
+  )
 
   const manifestContent = (
     <>
@@ -490,10 +630,10 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
           </TabList>
         </Box>
         <TabPanel value="codesystems" sx={{ p: 0 }}>
-          {manifestContent}
+          {vspManifestContent}
         </TabPanel>
         <TabPanel value="valuesets" sx={{ p: 0 }}>
-          {manifestContent}
+          {vspManifestContent}
         </TabPanel>
       </TabContext>
     )

--- a/vsm-app/components/ManifestDetailTable.tsx
+++ b/vsm-app/components/ManifestDetailTable.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, KeyboardEvent } from 'react'
 import DataTable, { TableColumn } from 'react-data-table-component'
 import InfoIcon from '@mui/icons-material/Info'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { IconButton } from './buttons/IconButton'
 import useSWR from 'swr'
 import { fetcher } from '@/utils'
@@ -8,6 +9,7 @@ import { ManifestSystemVersionPair, SelectedManifestDataVersion } from '@/types/
 import { customTableStyles } from './tables/themes'
 import { Typography, Modal, Tooltip, Box, Button as MuiButton, TextField, InputAdornment, Chip } from '@mui/material'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import EditIcon from '@mui/icons-material/Edit'
 import { modalStyle } from '@/styles'
 import { namesByUri, getNameByUri } from './EditManifestDetails/manifestHelpers'
 import SearchIcon from '@mui/icons-material/Search'
@@ -39,11 +41,42 @@ type ManifestDetailTableProps = {
   programId: string
   availableUpdates?: ManifestSystemVersionPair[]
   resourceType?: 'program' | 'vsp' // NEW: specify resource type
+  onUpdateVersion?: (system: string, oldVersion: string, newVersion: string) => void
+  unversionedSeverity?: 'warning' | 'info'
 }
 
-const ManifestDetailTable = ({ deleteFn, updateFn, manifestData, programId, availableUpdates, resourceType = 'program' }: ManifestDetailTableProps) => {
+const ManifestDetailTable = ({
+  deleteFn,
+  updateFn,
+  manifestData,
+  programId,
+  availableUpdates,
+  resourceType = 'program',
+  onUpdateVersion,
+  unversionedSeverity = 'warning'
+}: ManifestDetailTableProps) => {
   const [targetedCsToUpdate, setTargetedCsToUpdate] = useState<ManifestSystemVersionPair | null>(null)
   const [filterText, setFilterText] = useState('')
+  const [editingRowId, setEditingRowId] = useState<string | null>(null)
+  const [editingValue, setEditingValue] = useState('')
+
+  const editable = typeof onUpdateVersion === 'function'
+
+  const commitEdit = (row: ManifestSystemVersionPair) => {
+    const next = editingValue.trim()
+    if (next !== (row.version ?? '')) {
+      onUpdateVersion!(row.system!, row.version ?? '', next)
+    }
+    setEditingRowId(null)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, row: ManifestSystemVersionPair) => {
+    if (e.key === 'Enter') {
+      commitEdit(row)
+    } else if (e.key === 'Escape') {
+      setEditingRowId(null)
+    }
+  }
 
   // Use the correct API endpoint based on resource type
   const manifestEndpoint = programId
@@ -96,19 +129,70 @@ const ManifestDetailTable = ({ deleteFn, updateFn, manifestData, programId, avai
       sortable: true,
       wrap: true,
       cell: (row: ManifestSystemVersionPair) => {
-        if (!row.version) {
+        if (editable && editingRowId === row.id) {
           return (
-            <Tooltip title="Version not specified. Please resolve this entry by pinning a version." arrow>
+            <TextField
+              size="small"
+              autoFocus
+              value={editingValue}
+              onChange={(e) => setEditingValue(e.target.value)}
+              onBlur={() => commitEdit(row)}
+              onKeyDown={(e) => handleKeyDown(e as KeyboardEvent<HTMLInputElement>, row)}
+              placeholder="e.g. 2.74"
+              sx={{ minWidth: 140 }}
+              inputProps={{ 'data-edit-version': row.system }}
+            />
+          )
+        }
+
+        const startEdit = () => {
+          if (!editable) return
+          setEditingRowId(row.id ?? null)
+          setEditingValue(row.version ?? '')
+        }
+
+        if (!row.version) {
+          const isInfo = unversionedSeverity === 'info'
+          const tooltipText = isInfo
+            ? editable
+              ? 'No version pinned. Click to set one, or leave unversioned to let the terminology server choose.'
+              : 'No version pinned. The terminology server will choose a version during expansion.'
+            : 'Version not specified. Please resolve this entry by pinning a version.'
+          return (
+            <Tooltip title={tooltipText} arrow>
               <Chip
-                icon={<WarningAmberIcon />}
-                label="Unresolved"
+                icon={isInfo ? <InfoOutlinedIcon /> : <WarningAmberIcon />}
+                label={isInfo ? 'Unversioned' : 'Unresolved'}
                 size="small"
-                color="warning"
+                color={isInfo ? 'info' : 'warning'}
                 variant="outlined"
+                onClick={editable ? startEdit : undefined}
+                sx={editable ? { cursor: 'pointer' } : undefined}
               />
             </Tooltip>
           )
         }
+
+        if (editable) {
+          return (
+            <Box
+              onClick={startEdit}
+              sx={{
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 0.5,
+                borderRadius: 1,
+                '&:hover': { backgroundColor: 'action.hover' }
+              }}
+            >
+              <Typography variant="body2" component="span">{row.version}</Typography>
+              <EditIcon fontSize="inherit" sx={{ color: 'action.active', width: 14, height: 14 }} />
+            </Box>
+          )
+        }
+
         return row.version
       }
     },

--- a/vsm-app/components/VSPDetails/index.tsx
+++ b/vsm-app/components/VSPDetails/index.tsx
@@ -452,6 +452,7 @@ const VSPDetails = ({ program: initialVSP }: LibraryServerSideProps) => {
             ...manifestData.valueSets
           }}
           resourceType="vsp"
+          unversionedSeverity="info"
         />
       </ManifestContainer>
     </Col>

--- a/vsm-app/helpers/valueSetHelpers.spec.ts
+++ b/vsm-app/helpers/valueSetHelpers.spec.ts
@@ -12,7 +12,10 @@ import {
   organizeValueSetDefinitionData,
   setExpansionParametersForVSP,
   getVSPManifestVersions,
-  getProgramManifestVersions
+  getProgramManifestVersions,
+  filterToUnversioned,
+  applyVersionUpdate,
+  applyAddManifestEntry
 } from './valueSetHelpers'
 import { uniq } from 'lodash'
 import { DeleteData, UpdateData } from '@/pages/api/codesystem/provisional';
@@ -1119,6 +1122,145 @@ describe('VSP Manifest Functions', () => {
       const result = getProgramManifestVersions(library)
       expect(result['http://loinc.org']).toEqual(['2.74'])
       expect(result['http://snomed.info/sct']).toEqual([''])
+    })
+  })
+
+  describe('filterToUnversioned', () => {
+    it('returns empty object when input is empty', () => {
+      expect(filterToUnversioned({})).toEqual({})
+    })
+
+    it('returns empty object when input is null or undefined', () => {
+      expect(filterToUnversioned(undefined as any)).toEqual({})
+      expect(filterToUnversioned(null as any)).toEqual({})
+    })
+
+    it('returns empty object when every entry has a pinned version', () => {
+      const input = {
+        'http://loinc.org': ['2.74'],
+        'http://snomed.info/sct': ['20240301']
+      }
+      expect(filterToUnversioned(input)).toEqual({})
+    })
+
+    it('retains entries with empty-string versions', () => {
+      const input = {
+        'http://loinc.org': [''],
+        'http://snomed.info/sct': ['20240301']
+      }
+      expect(filterToUnversioned(input)).toEqual({ 'http://loinc.org': [''] })
+    })
+
+    it('treats whitespace-only versions as unversioned', () => {
+      const input = {
+        'http://loinc.org': ['   '],
+        'http://snomed.info/sct': ['\t']
+      }
+      expect(filterToUnversioned(input)).toEqual({
+        'http://loinc.org': ['   '],
+        'http://snomed.info/sct': ['\t']
+      })
+    })
+
+    it('keeps only the unversioned entries when a system has a mix', () => {
+      const input = {
+        'http://loinc.org': ['2.74', '', '2.75']
+      }
+      expect(filterToUnversioned(input)).toEqual({ 'http://loinc.org': [''] })
+    })
+
+    it('does not mutate the input', () => {
+      const input = {
+        'http://loinc.org': ['', '2.74']
+      }
+      const snapshot = JSON.parse(JSON.stringify(input))
+      filterToUnversioned(input)
+      expect(input).toEqual(snapshot)
+    })
+  })
+
+  describe('applyVersionUpdate', () => {
+    it('replaces an existing version in place (order preserved)', () => {
+      const input = {
+        'http://loinc.org': ['2.73', '2.74', '2.75']
+      }
+      const result = applyVersionUpdate(input, 'http://loinc.org', '2.74', '2.74a')
+      expect(result['http://loinc.org']).toEqual(['2.73', '2.74a', '2.75'])
+    })
+
+    it('appends newVersion when oldVersion is not found', () => {
+      const input = {
+        'http://loinc.org': ['2.73']
+      }
+      const result = applyVersionUpdate(input, 'http://loinc.org', '2.99', '2.74')
+      expect(result['http://loinc.org']).toEqual(['2.73', '2.74'])
+    })
+
+    it('does not append when newVersion already exists and oldVersion is not found', () => {
+      const input = {
+        'http://loinc.org': ['2.73']
+      }
+      const result = applyVersionUpdate(input, 'http://loinc.org', '2.99', '2.73')
+      expect(result['http://loinc.org']).toEqual(['2.73'])
+    })
+
+    it('creates the system entry if missing', () => {
+      const result = applyVersionUpdate({}, 'http://loinc.org', '', '2.74')
+      expect(result['http://loinc.org']).toEqual(['2.74'])
+    })
+
+    it('can replace a versioned entry with an empty-string version (unpin)', () => {
+      const input = {
+        'http://loinc.org': ['2.74']
+      }
+      const result = applyVersionUpdate(input, 'http://loinc.org', '2.74', '')
+      expect(result['http://loinc.org']).toEqual([''])
+    })
+
+    it('does not mutate the input', () => {
+      const input = {
+        'http://loinc.org': ['2.73', '2.74']
+      }
+      const snapshot = JSON.parse(JSON.stringify(input))
+      applyVersionUpdate(input, 'http://loinc.org', '2.74', '2.75')
+      expect(input).toEqual(snapshot)
+    })
+  })
+
+  describe('applyAddManifestEntry', () => {
+    it('adds a new canonical with the given version', () => {
+      const result = applyAddManifestEntry({}, 'http://loinc.org', '2.74')
+      expect(result['http://loinc.org']).toEqual(['2.74'])
+    })
+
+    it('appends a version to an existing canonical', () => {
+      const input = {
+        'http://loinc.org': ['2.73']
+      }
+      const result = applyAddManifestEntry(input, 'http://loinc.org', '2.74')
+      expect(result['http://loinc.org']).toEqual(['2.73', '2.74'])
+    })
+
+    it('dedupes when the same version is added again', () => {
+      const input = {
+        'http://loinc.org': ['2.74']
+      }
+      const result = applyAddManifestEntry(input, 'http://loinc.org', '2.74')
+      expect(result['http://loinc.org']).toEqual(['2.74'])
+    })
+
+    it('adds an unversioned entry when version is empty string', () => {
+      const result = applyAddManifestEntry({}, 'http://loinc.org', '')
+      expect(result['http://loinc.org']).toEqual([''])
+    })
+
+    it('does not mutate the input', () => {
+      const input = {
+        'http://loinc.org': ['2.74']
+      }
+      const snapshot = JSON.parse(JSON.stringify(input))
+      applyAddManifestEntry(input, 'http://snomed.info/sct', '20240301')
+      expect(input).toEqual(snapshot)
     })
   })
 })

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -358,6 +358,69 @@ const getVSPManifestVersions = (library: fhir4.Library): { codeSystems: Selected
   return { codeSystems, valueSets }
 }
 
+/**
+ * Returns a copy of `data` containing only the canonicals whose version list
+ * has at least one unversioned entry (empty/whitespace). Each retained system
+ * has its version list filtered to just the unversioned entries.
+ * Pure: does not mutate `data`.
+ */
+const filterToUnversioned = (data: SelectedManifestDataVersion): SelectedManifestDataVersion => {
+  const result: SelectedManifestDataVersion = {}
+  Object.entries(data || {}).forEach(([system, versions]) => {
+    const unversionedOnly = (versions || []).filter((v) => !v || v.trim() === '')
+    if (unversionedOnly.length > 0) {
+      result[system] = unversionedOnly
+    }
+  })
+  return result
+}
+
+/**
+ * Returns a copy of `data` with the version pin for `system` updated.
+ * - If `oldVersion` is present in the system's version list, it is replaced
+ *   in place with `newVersion` (order preserved).
+ * - If `oldVersion` is not present, `newVersion` is appended (de-duped).
+ * - If `system` doesn't exist in `data`, it is created with `[newVersion]`.
+ * Pure: does not mutate `data`.
+ */
+const applyVersionUpdate = (
+  data: SelectedManifestDataVersion,
+  system: string,
+  oldVersion: string,
+  newVersion: string
+): SelectedManifestDataVersion => {
+  const next: SelectedManifestDataVersion = structuredClone(data || {})
+  const versions = [...(next[system] ?? [])]
+  const idx = versions.indexOf(oldVersion)
+  if (idx >= 0) {
+    versions[idx] = newVersion
+  } else if (!versions.includes(newVersion)) {
+    versions.push(newVersion)
+  }
+  next[system] = versions
+  return next
+}
+
+/**
+ * Returns a copy of `data` with a new manifest entry appended.
+ * - If `canonical` already has versions, `version` is appended unless already present.
+ * - If `canonical` is new, it is added with `[version]`.
+ * Pure: does not mutate `data`.
+ */
+const applyAddManifestEntry = (
+  data: SelectedManifestDataVersion,
+  canonical: string,
+  version: string
+): SelectedManifestDataVersion => {
+  const next: SelectedManifestDataVersion = structuredClone(data || {})
+  const versions = [...(next[canonical] ?? [])]
+  if (!versions.includes(version)) {
+    versions.push(version)
+  }
+  next[canonical] = versions
+  return next
+}
+
 // update grouper valueset with proper version
 const updateLeafVsVersion = (vs: fhir4.ValueSet, canonicalToUpdate: string, version: string): fhir4.ValueSet => {
   const vsCopy = cloneDeep(vs)
@@ -739,5 +802,8 @@ export {
   urlWithoutPinnedVersion,
   // VSP-specific manifest functions
   setExpansionParametersForVSP,
-  getVSPManifestVersions
+  getVSPManifestVersions,
+  filterToUnversioned,
+  applyVersionUpdate,
+  applyAddManifestEntry
 }


### PR DESCRIPTION
## Summary

  - Reworks the VSP edit-manifest workflow so versions are pinned by free-text input instead of choosing from VSAC's per-system version list. The VSAC catalog is no longer queried at all on the VSP path. Program manifest editing is untouched.
  - New layout for the VSP edit page: drops the left "Available Versions" pane, the system picker, and the "Find Newest Versions" / "Scan ValueSets" buttons. Replaces them with an inline Add panel (free-text Canonical URL + free-text Version) and a Show only unversioned filter toggle above the manifest table.
  - ManifestDetailTable gains onUpdateVersion and unversionedSeverity props. When onUpdateVersion is provided, the version cell becomes inline-editable (click → text field, Enter or blur to commit, Escape to cancel; the canonical stays read-only). When unversionedSeverity="info", the empty-version chip switches from amber "Unresolved" with a warning tooltip to neutral "Unversioned" with InfoOutlined and a tooltip explaining the terminology server will pick the version.
  - VSP detail view (VSPDetails) also passes unversionedSeverity="info" so the read-only manifest table renders the same neutral chip as the edit page. ProgramDetails and ReleaseModal (Program release flow) keep their existing warning treatment.
  - Persistence flow unchanged: every commit fires PUT /api/value-set-packages/{id}/manifest, which rewrites the contained expansion-parameters-vsp Parameters in place and saves the Library back to the FHIR server. No-op edits (commit without changing the value) short-circuit before the network call.
  - Extracts three pure helpers in helpers/valueSetHelpers.ts — filterToUnversioned, applyVersionUpdate, applyAddManifestEntry — and refactors EditManifestDetails handlers to call them.
  - 18 new unit tests covering the helpers (empty inputs, in-place replacement preserving order, append when not found, dedupe, whitespace-only versions treated as unversioned, no input mutation across all three).
  - Performance: skips the page-level SWR fetch of the VSAC catalog for VSPs (apiEndpoint = null) and removes the loading gate that previously blocked first paint on that fetch. The manifest page now renders immediately from the program prop on the VSP path; friendly names in the Name column fill in asynchronously via ManifestDetailTable's own SWR.
  - Bug fix: displayManifestData useMemo was originally placed below the component's early returns, causing a Rendered more hooks than during the previous render error when the loading state flipped. Moved above the early returns.
  
## Test plan

  - Open Edit Manifest on a draft VSP and confirm the page renders immediately (no spinner gating on the catalog fetch), tabs switch without a delay, and the layout shows the Add panel and toggle above the manifest table.
  - In the Add panel, enter a new canonical and version and click Add; confirm the entry appears in the table and persists across a page reload.
  - In the Add panel, enter a canonical with empty version; confirm the entry appears with the neutral "Unversioned" info chip.
  - Click an existing version cell; confirm the inline text field appears, Enter commits, blur commits, Escape cancels, and a no-op (commit without changes) does not fire the PUT.
  - Toggle Show only unversioned; confirm the table filters to entries with an empty version (treating whitespace-only as unversioned).
  - Open the VSP detail page (read-only); confirm the unversioned chip uses the info treatment (icon + neutral color).
  - Open the Program edit manifest page; confirm the VSAC dropdown, "Available Versions" pane, and "Find Newest Versions" / "Scan ValueSets" buttons still work as before (regression check on the unchanged path).
  - Try to edit a manifest on a non-draft VSP if reachable; confirm the server-side 400 surfaces a sane error rather than silent failure.
  - npx jest helpers/valueSetHelpers.spec.ts — full suite passes (48 tests).