### PR TITLE
Add CodeSystem version lookup to VSP manifest editor

### DIFF
--- a/vsm-app/components/EditManifestDetails/index.tsx
+++ b/vsm-app/components/EditManifestDetails/index.tsx
@@ -23,7 +23,7 @@ import Tooltip from '@mui/material/Tooltip'
 import { ErrorMessage } from '@/components/ErrorMessage'
 import LoadingIndicator from '../LoadingIndicator'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
-import { Tab, FormControlLabel, Switch, TextField, Stack } from '@mui/material'
+import { Tab, FormControlLabel, Switch, TextField, Stack, Autocomplete, CircularProgress } from '@mui/material'
 import { is } from '@/helpers/is'
 import {
   getIdFromSystem,
@@ -104,6 +104,43 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
   const [addCanonical, setAddCanonical] = useState('')
   const [addVersion, setAddVersion] = useState('')
   const [showOnlyUnversioned, setShowOnlyUnversioned] = useState(false)
+  const [fetchedVersions, setFetchedVersions] = useState<string[]>([])
+  const [fetchingVersions, setFetchingVersions] = useState(false)
+  const [versionsSource, setVersionsSource] = useState<string | null>(null)
+
+  // Reset fetched versions when canonical or tab changes — they were tied to the prior canonical.
+  useEffect(() => {
+    setFetchedVersions([])
+    setVersionsSource(null)
+  }, [addCanonical, manifestTab])
+
+  const handleFetchVersions = async () => {
+    const canonical = addCanonical.trim()
+    if (!canonical) return
+    setFetchingVersions(true)
+    try {
+      const response = await apiFetch(`/api/codesystem-versions?canonical=${encodeURIComponent(canonical)}`)
+      const result = await response.json()
+      if (!response.ok) {
+        toast.error(result?.error || 'Failed to fetch versions')
+        setFetchedVersions([])
+        setVersionsSource(null)
+        return
+      }
+      const versions: string[] = Array.isArray(result?.versions) ? result.versions : []
+      setFetchedVersions(versions)
+      setVersionsSource(result?.source?.endpointAddress || null)
+      if (versions.length === 0) {
+        toast.info(`No versions returned for ${canonical}`)
+      }
+    } catch (e: any) {
+      toast.error(e?.message || 'Failed to fetch versions')
+      setFetchedVersions([])
+      setVersionsSource(null)
+    } finally {
+      setFetchingVersions(false)
+    }
+  }
 
   // Determine API endpoint based on whether it's a VSP or Program.
   // VSPs don't need this catalog at all — the dropdown is gone and
@@ -355,15 +392,30 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
             sx={{ flex: 2 }}
             inputProps={{ 'data-add-canonical': true }}
           />
-          <TextField
+          <Autocomplete
+            freeSolo
             size="small"
-            label="Version (optional)"
-            placeholder="e.g. 2.74"
+            options={fetchedVersions}
             value={addVersion}
-            onChange={(e) => setAddVersion(e.target.value)}
+            onInputChange={(_e, value) => setAddVersion(value)}
             sx={{ flex: 1 }}
-            inputProps={{ 'data-add-version': true }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Version (optional)"
+                placeholder="e.g. 2.74"
+                inputProps={{ ...params.inputProps, 'data-add-version': true }}
+              />
+            )}
           />
+          {manifestTab === 'codesystems' && (
+            <Button
+              text={fetchingVersions ? 'Fetching…' : 'Fetch versions'}
+              disabled={fetchingVersions || !addCanonical.trim()}
+              loading={fetchingVersions}
+              onClick={handleFetchVersions}
+            />
+          )}
           <Button
             text="Add"
             disabled={isUpdating || !addCanonical.trim()}
@@ -374,6 +426,11 @@ const EditManifestDetails = ({ program }: { program: fhir4.Library }) => {
         <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
           Leave the version empty to add an unversioned entry — the terminology server will choose the version during expansion.
         </Typography>
+        {versionsSource && fetchedVersions.length > 0 && (
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+            Showing {fetchedVersions.length} version{fetchedVersions.length === 1 ? '' : 's'} from {versionsSource}.
+          </Typography>
+        )}
       </Box>
       <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
         <FormControlLabel

--- a/vsm-app/helpers/server/endpointResolution.spec.ts
+++ b/vsm-app/helpers/server/endpointResolution.spec.ts
@@ -1,0 +1,85 @@
+import { pickEndpointForCanonical } from './endpointResolution'
+import { ARTIFACT_ROUTE_URL } from '@/constants'
+
+const makeEndpoint = (id: string, address: string, artifactRoute?: string): fhir4.Endpoint => ({
+  resourceType: 'Endpoint',
+  id,
+  status: 'active',
+  connectionType: {
+    system: 'http://terminology.hl7.org/CodeSystem/endpoint-connection-type',
+    code: 'hl7-fhir-rest'
+  },
+  payloadType: [{ coding: [{ code: 'none' }] }],
+  address,
+  ...(artifactRoute !== undefined && {
+    extension: [{ url: ARTIFACT_ROUTE_URL, valueUri: artifactRoute }]
+  })
+})
+
+describe('pickEndpointForCanonical', () => {
+  it('returns undefined when canonical is empty', () => {
+    expect(pickEndpointForCanonical('', [makeEndpoint('a', 'https://a')])).toBeUndefined()
+  })
+
+  it('returns undefined when endpoints list is empty', () => {
+    expect(pickEndpointForCanonical('http://loinc.org', [])).toBeUndefined()
+  })
+
+  it('matches an endpoint whose artifactRoute is a prefix of the canonical', () => {
+    const ep = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://cts.nlm.nih.gov/fhir')
+    const result = pickEndpointForCanonical('http://cts.nlm.nih.gov/fhir/ValueSet/123', [ep])
+    expect(result?.id).toBe('vsac')
+  })
+
+  it('does not match when the canonical does not start with the route', () => {
+    const ep = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://cts.nlm.nih.gov/fhir')
+    const result = pickEndpointForCanonical('http://loinc.org', [ep])
+    expect(result).toBeUndefined()
+  })
+
+  it('falls back to the no-artifactRoute endpoint when no route matches', () => {
+    const fallback = makeEndpoint('default', 'https://tx.fhir.org/r4')
+    const vsac = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://cts.nlm.nih.gov/fhir')
+    const result = pickEndpointForCanonical('http://loinc.org', [vsac, fallback])
+    expect(result?.id).toBe('default')
+  })
+
+  it('prefers a matched route over the fallback', () => {
+    const fallback = makeEndpoint('default', 'https://tx.fhir.org/r4')
+    const vsac = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://cts.nlm.nih.gov/fhir')
+    const result = pickEndpointForCanonical('http://cts.nlm.nih.gov/fhir/CodeSystem/foo', [vsac, fallback])
+    expect(result?.id).toBe('vsac')
+  })
+
+  it('picks the longest-prefix match when multiple routes match', () => {
+    const broad = makeEndpoint('broad', 'https://broad', 'http://hl7.org/fhir')
+    const narrow = makeEndpoint('narrow', 'https://narrow', 'http://hl7.org/fhir/us/core')
+    const result = pickEndpointForCanonical('http://hl7.org/fhir/us/core/CodeSystem/x', [broad, narrow])
+    expect(result?.id).toBe('narrow')
+  })
+
+  it('picks the longest-prefix match regardless of declaration order', () => {
+    const narrow = makeEndpoint('narrow', 'https://narrow', 'http://hl7.org/fhir/us/core')
+    const broad = makeEndpoint('broad', 'https://broad', 'http://hl7.org/fhir')
+    const result = pickEndpointForCanonical('http://hl7.org/fhir/us/core/CodeSystem/x', [narrow, broad])
+    expect(result?.id).toBe('narrow')
+  })
+
+  it('treats an artifactRoute extension with an empty valueUri as no-route (fallback candidate)', () => {
+    const ep = makeEndpoint('partial', 'https://partial', '')
+    const result = pickEndpointForCanonical('http://loinc.org', [ep])
+    expect(result?.id).toBe('partial')
+  })
+
+  it('is case-sensitive when matching the prefix', () => {
+    const ep = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://Cts.Nlm.Nih.Gov/fhir')
+    const result = pickEndpointForCanonical('http://cts.nlm.nih.gov/fhir/CodeSystem/x', [ep])
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when there is no match and no fallback', () => {
+    const vsac = makeEndpoint('vsac', 'https://cts.nlm.nih.gov/fhir', 'http://cts.nlm.nih.gov/fhir')
+    const result = pickEndpointForCanonical('http://loinc.org', [vsac])
+    expect(result).toBeUndefined()
+  })
+})

--- a/vsm-app/helpers/server/endpointResolution.ts
+++ b/vsm-app/helpers/server/endpointResolution.ts
@@ -1,0 +1,50 @@
+import { ARTIFACT_ROUTE_URL } from '@/constants'
+
+/**
+ * Returns the `crmi-artifactRoute` extension value on an Endpoint, or undefined
+ * if the extension is absent / has no value.
+ */
+const getArtifactRoute = (endpoint: fhir4.Endpoint): string | undefined => {
+  const value = endpoint.extension?.find((ext) => ext.url === ARTIFACT_ROUTE_URL)?.valueUri
+  return value && value.length > 0 ? value : undefined
+}
+
+/**
+ * Picks the terminology Endpoint that should serve queries for `canonical`.
+ *
+ * Routing rules:
+ * 1. Among endpoints whose `crmi-artifactRoute` is a prefix of `canonical`,
+ *    pick the one with the longest route (most specific match).
+ * 2. If no endpoint matches, fall back to the single endpoint that has no
+ *    `crmi-artifactRoute` extension (the "default" terminology server).
+ * 3. If neither a match nor a fallback exists, return `undefined`.
+ *
+ * Pure: does not perform I/O.
+ */
+const pickEndpointForCanonical = (
+  canonical: string,
+  endpoints: fhir4.Endpoint[]
+): fhir4.Endpoint | undefined => {
+  if (!canonical || !endpoints?.length) return undefined
+
+  let best: { endpoint: fhir4.Endpoint; routeLength: number } | undefined
+  let fallback: fhir4.Endpoint | undefined
+
+  for (const endpoint of endpoints) {
+    const route = getArtifactRoute(endpoint)
+    if (route === undefined) {
+      // Convention: there is at most one no-artifactRoute fallback endpoint.
+      if (!fallback) fallback = endpoint
+      continue
+    }
+    if (canonical.startsWith(route)) {
+      if (!best || route.length > best.routeLength) {
+        best = { endpoint, routeLength: route.length }
+      }
+    }
+  }
+
+  return best?.endpoint ?? fallback
+}
+
+export { getArtifactRoute, pickEndpointForCanonical }

--- a/vsm-app/helpers/server/resolveTerminologyEndpoint.ts
+++ b/vsm-app/helpers/server/resolveTerminologyEndpoint.ts
@@ -1,0 +1,49 @@
+import FhirClient from '@/backend/clients/FhirCdrClient'
+import { tsCredentialService } from '@/backend/services/TsCredentialService'
+import { TerminologyServerCredentials } from '@/backend/model/TerminologyServerCredential'
+import { pickEndpointForCanonical } from '@/helpers/server/endpointResolution'
+
+interface ResolvedTerminologyEndpoint {
+  endpoint: fhir4.Endpoint
+  credentials?: TerminologyServerCredentials
+}
+
+/**
+ * Returns the terminology Endpoint that should serve queries for `canonical`,
+ * along with the requesting user's stored credentials for that Endpoint (if any).
+ *
+ * Uses `pickEndpointForCanonical` for the routing rules (longest-prefix
+ * artifactRoute match, falling back to the no-artifactRoute Endpoint).
+ *
+ * Throws when no Endpoint can be resolved for the canonical.
+ * Returns the Endpoint without credentials when the user has not configured
+ * any for it — callers should decide whether to proceed unauthenticated.
+ */
+const resolveTerminologyEndpointForCanonical = async (
+  userId: string,
+  canonical: string
+): Promise<ResolvedTerminologyEndpoint> => {
+  const endpointBundle = (await FhirClient.getInstance().search({
+    resourceType: 'Endpoint',
+    searchParams: { identifier: 'terminologyEndpoint' }
+  })) as fhir4.Bundle
+  const endpoints = endpointBundle?.entry?.map((e) => e.resource as fhir4.Endpoint) || []
+  const endpoint = pickEndpointForCanonical(canonical, endpoints)
+  if (!endpoint) {
+    throw new Error(`No terminology server configured for canonical: ${canonical}`)
+  }
+
+  let credentials: TerminologyServerCredentials | undefined
+  try {
+    credentials = await tsCredentialService.getCredentials(userId, endpoint.id!)
+  } catch {
+    // No stored credentials for this user + endpoint pair. That's allowed —
+    // some endpoints (or some queries) are reachable unauthenticated.
+    credentials = undefined
+  }
+
+  return { endpoint, credentials }
+}
+
+export { resolveTerminologyEndpointForCanonical }
+export type { ResolvedTerminologyEndpoint }

--- a/vsm-app/pages/api/codesystem-versions.ts
+++ b/vsm-app/pages/api/codesystem-versions.ts
@@ -53,7 +53,7 @@ const getCodeSystemVersions = async (
     return res.status(500).json({ error: 'Resolved Endpoint has no address configured' })
   }
 
-  const url = `${baseUrl}/CodeSystem?url=${encodeURIComponent(canonical)}&_summary=true&_count=200`
+  const url = `${baseUrl}/CodeSystem?url=${encodeURIComponent(canonical)}&_count=200`
   const headers: Record<string, string> = { Accept: 'application/fhir+json' }
   if (credentials?.username && credentials?.password) {
     const basic = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64')

--- a/vsm-app/pages/api/codesystem-versions.ts
+++ b/vsm-app/pages/api/codesystem-versions.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetch as f } from 'undici'
+import handler from '@/helpers/server/handler'
+import Logger from '@/helpers/server/logger'
+import { VSMSession } from '@/helpers/rolesHelper'
+import { resolveTerminologyEndpointForCanonical } from '@/helpers/server/resolveTerminologyEndpoint'
+import { getArtifactRoute } from '@/helpers/server/endpointResolution'
+
+interface VersionsResponse {
+  versions: string[]
+  source: {
+    endpointId: string
+    endpointAddress: string
+    artifactRoute?: string
+  }
+}
+
+interface ErrorResponse {
+  error: string
+}
+
+/**
+ * GET /api/codesystem-versions?canonical={canonical}
+ *
+ * Resolves the terminology Endpoint that should serve queries for the canonical
+ * (longest-prefix artifactRoute match, falling back to the Endpoint with no
+ * artifactRoute), then calls `CodeSystem?url={canonical}&_summary=true` against
+ * it and returns the distinct `version` values.
+ */
+const getCodeSystemVersions = async (
+  req: NextApiRequest,
+  res: NextApiResponse<VersionsResponse | ErrorResponse>,
+  session: VSMSession
+) => {
+  const canonical = (req.query.canonical as string | undefined)?.trim()
+  if (!canonical) {
+    return res.status(400).json({ error: 'Missing required query parameter: canonical' })
+  }
+
+  let endpoint: fhir4.Endpoint
+  let credentials
+  try {
+    const resolved = await resolveTerminologyEndpointForCanonical(session.user.id, canonical)
+    endpoint = resolved.endpoint
+    credentials = resolved.credentials
+  } catch (e: any) {
+    Logger.getLogger().warn(`No terminology server configured for canonical: ${canonical}`)
+    return res.status(404).json({ error: e?.message || 'No terminology server configured for this canonical' })
+  }
+
+  const baseUrl = endpoint.address?.replace(/\/$/, '')
+  if (!baseUrl) {
+    return res.status(500).json({ error: 'Resolved Endpoint has no address configured' })
+  }
+
+  const url = `${baseUrl}/CodeSystem?url=${encodeURIComponent(canonical)}&_summary=true&_count=200`
+  const headers: Record<string, string> = { Accept: 'application/fhir+json' }
+  if (credentials?.username && credentials?.password) {
+    const basic = Buffer.from(`${credentials.username}:${credentials.password}`).toString('base64')
+    headers.Authorization = `Basic ${basic}`
+  }
+
+  Logger.getLogger().info(`Fetching CodeSystem versions for ${canonical} from ${baseUrl}`)
+
+  let bundle: fhir4.Bundle
+  try {
+    const response = await f(url, { method: 'GET', headers })
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      Logger.getLogger().warn(`Terminology server returned ${response.status} for ${url}: ${text}`)
+      return res.status(502).json({ error: `Terminology server returned ${response.status}` })
+    }
+    bundle = (await response.json()) as fhir4.Bundle
+  } catch (e: any) {
+    Logger.getLogger().error(`Failed to query terminology server: ${e?.message || e}`)
+    return res.status(502).json({ error: e?.message || 'Failed to query terminology server' })
+  }
+
+  const versions: string[] = []
+  for (const entry of bundle.entry ?? []) {
+    const resource = entry.resource as fhir4.CodeSystem | undefined
+    const version = resource?.version
+    if (version && !versions.includes(version)) {
+      versions.push(version)
+    }
+  }
+
+  return res.status(200).json({
+    versions,
+    source: {
+      endpointId: endpoint.id!,
+      endpointAddress: baseUrl,
+      artifactRoute: getArtifactRoute(endpoint)
+    }
+  })
+}
+
+export default handler({
+  GET: { access: ['admin', 'publisher', 'editor', 'reviewer'], action: getCodeSystemVersions }
+})


### PR DESCRIPTION
## Summary

  - Adds a Fetch versions button to the VSP edit-manifest Add panel (CodeSystem tab only). When the user enters a canonical URL and clicks Fetch, the app queries the appropriate terminology server for available versions and surfaces them as autocomplete suggestions on the Version field. The Version input stays freeSolo so users can still type a manual version that the server didn't list (provisional versions, pre-release, etc.).
  - Server selection is driven by the configured Endpoint resources' crmi-artifactRoute extension: longest-prefix match of the canonical against any endpoint's route wins. When no route matches, the request falls back to the single Endpoint that has no crmi-artifactRoute configured (the default terminology server, by convention always available).
  - New API route GET /api/codesystem-versions?canonical={url} resolves the endpoint, attaches the requesting user's stored credentials via tsCredentialService.getCredentials(userId, endpoint.id) when available, queries {endpointAddress}/CodeSystem?url={canonical}&_summary=true&_count=200, parses the returned Bundle, and responds with { versions, source }. The source payload (endpoint id, address, optional artifactRoute) lets the UI show where the versions came from.
  - New server-side helpers:
    - helpers/server/endpointResolution.ts - pure routing: pickEndpointForCanonical(canonical, endpoints) and getArtifactRoute(endpoint). No I/O, easy to unit-test.
    - helpers/server/resolveTerminologyEndpoint.ts - composes Endpoint search + routing + credential lookup into a single resolveTerminologyEndpointForCanonical(userId, canonical) call returning { endpoint, credentials? }. Returns the Endpoint without credentials (rather than throwing) when none are stored — endpoints that allow unauthenticated reads still work.
  - 11 unit tests for pickEndpointForCanonical: empty inputs, prefix matching, no-match falls back to no-artifactRoute Endpoint, longest-prefix wins, declaration-order independence, case sensitivity, no-fallback returns undefined.
  - Scope: VSP CodeSystem tab only. ValueSet tab is unchanged (still free-text); Program edit page is unchanged. VSPPackageQueue's hardcoded artifact route is untouched (separate concern).

## Test plan

  - In Settings, confirm the existing terminology Endpoint configuration still loads (no regression on Endpoint shape).
  - Open Edit Manifest on a draft VSP, CodeSystem tab. Type a canonical that matches a configured crmi-artifactRoute (e.g. an http://cts.nlm.nih.gov/fhir/... URL when VSAC is configured). Click Fetch versions; confirm the Version field opens an autocomplete listing the returned versions, and the inline caption shows the endpoint address.
  - Pick a version from the autocomplete and click Add; confirm the entry appears in the manifest table and persists across reload.
  - Repeat with a manually typed version (not in the fetched list); confirm freeSolo keeps the value and Add still works.
  - Type a canonical that doesn't match any configured artifactRoute and click Fetch; confirm the fallback Endpoint (no artifactRoute) is used. Inline caption reports its address.
  - Remove the fallback Endpoint from Settings, retry a non-matching canonical; confirm a 404 error toast surfaces ("No terminology server configured for this canonical").
  - Hit /api/codesystem-versions?canonical=... from a logged-in browser session directly; confirm the response shape matches { versions: string[], source: { endpointId, endpointAddress, artifactRoute? } }.
  - Switch to the ValueSet tab; confirm the Fetch versions button is not present and the Add flow is unchanged.
  - Open Edit Manifest on a Program; confirm the VSAC version dropdown still works (regression check on the unchanged path).
  - npx jest helpers/server/endpointResolution.spec.ts - 11 tests pass.