### PR TITLE
Repair terminology endpoint credential management and validation

### DIFF
--- a/vsm-app/components/TerminologyServerForm/types.ts
+++ b/vsm-app/components/TerminologyServerForm/types.ts
@@ -1,8 +1,9 @@
 import { Options } from 'react-select'
+import { AUTH_TYPE } from '@/constants'
 
 export const authenticationTypes = {
-  none: 'No Authentication',
-  basic: 'Basic Authentication',
+  [AUTH_TYPE.NONE]: 'No Authentication',
+  [AUTH_TYPE.BASIC]: 'Basic Authentication',
 }
 
 export const authenticationOptions: Options<{ value: string; label: string }> = Object.entries(

--- a/vsm-app/constants.ts
+++ b/vsm-app/constants.ts
@@ -2,6 +2,14 @@
 export const AUTHENTICATION_TYPE_URL = 'http://aphl.org/fhir/vsm/StructureDefinition/vsm-endpoint-authentication-type'
 export const ARTIFACT_ROUTE_URL = 'http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-artifactRoute'
 
+// Auth-type values stored in the AUTHENTICATION_TYPE_URL extension's valueString.
+// These are the option KEYS (not labels) and must stay the single source of truth
+// shared by the endpoint form, the settings page, and the validation API route.
+export const AUTH_TYPE = {
+  NONE: 'none',
+  BASIC: 'basic'
+} as const
+
 export const VSM_META_PROFILE_URLS = {
   VSM_GROUPERVALUESET_URL: 'http://aphl.org/fhir/vsm/StructureDefinition/vsm-groupervalueset'
 }

--- a/vsm-app/hooks/useTestTermEndpoint.ts
+++ b/vsm-app/hooks/useTestTermEndpoint.ts
@@ -12,6 +12,7 @@ const useTestTermEndpoint = (serverData: ServerData) => {
   const { data, error, isLoading, mutate } = useSWR(endpointId ? endpoint : null, fetcher)
   return {
     isEndpointValid: data?.status === 'ok',
+    needsCredentials: data?.status === 'no-credentials',
     pingLoading: isLoading,
     pingError: error,
     pingMutate: mutate

--- a/vsm-app/pages/api/test-terminology-endpoint.ts
+++ b/vsm-app/pages/api/test-terminology-endpoint.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import TerminologyFhirClient from '@/backend/clients/TerminologyFhirClient'
+import FhirKitClient from 'fhir-kit-client'
 import { tsCredentialService } from '@/backend/services/TsCredentialService'
 import { VSMSession } from '@/helpers/rolesHelper'
 import handler from '@/helpers/server/handler'
@@ -11,48 +11,78 @@ const testTermEndpoint = async (req: NextApiRequest, res: NextApiResponse, sessi
   try {
     const { endpointId } = req.query
 
-    const endpointBundle = await FhirClient.getInstance().search({
-      resourceType: 'Endpoint',
-    })
-
-    const endpoints = endpointBundle?.entry?.map((e: fhir4.BundleEntry) => e?.resource as fhir4.Endpoint)
-
-    const matchingEndpoint = endpoints?.find((e: fhir4.Endpoint) => e?.id === endpointId)
-
-    // early return if no matching endpoint exists
-    if (!matchingEndpoint) {
-      return res.status(500).json({ error: 'No active terminology server endpoint' })
+    if (!endpointId) {
+      return res.status(400).json({ error: 'endpointId is required' })
     }
 
+    // Read the endpoint directly by id. A prior implementation searched all
+    // Endpoints (unfiltered, unpaginated) and found by id, which silently failed
+    // for any endpoint outside the server's default result window — e.g. a
+    // freshly-created one — making it perpetually "invalid".
+    let matchingEndpoint: fhir4.Endpoint | undefined
+    try {
+      matchingEndpoint = (await FhirClient.getInstance().read({
+        resourceType: 'Endpoint',
+        id: endpointId as string
+      })) as fhir4.Endpoint
+    } catch {
+      matchingEndpoint = undefined
+    }
+
+    if (!matchingEndpoint) {
+      return res.status(404).json({ error: 'Terminology endpoint not found' })
+    }
+
+    // Stored value is the option KEY ('basic' | 'none'), not the label — see
+    // TerminologyServerForm/types.ts (authenticationTypes) and the form's submit.
     const authType = matchingEndpoint.extension?.find((ext: fhir4.Extension) => ext.url === AUTHENTICATION_TYPE_URL)?.valueString
     let basicAuthHeader: string | undefined
-    if (authType === 'Basic Authentication') {
-      const authCredentials = await tsCredentialService.getCredentials(session?.user?.id, endpointId as string)
-      basicAuthHeader = Buffer.from(`${authCredentials.username}:${authCredentials.password}`).toString('base64')
-    }
-
-    TerminologyFhirClient.setCustomClient({
-      clientName: matchingEndpoint.name as string,
-      baseUrl: matchingEndpoint.address as string,
-      basicAuthHeader
-    })
-
-    const activeTerminologyClient = await TerminologyFhirClient.getClient()
-    if (activeTerminologyClient) {
-      const serverResponse = await activeTerminologyClient.request('/metadata')
-      // @ts-ignore
-      if (serverResponse?.resourceType == 'CapabilityStatement') {
-        return res.status(200).json({ status: 'ok' })
+    if (authType === 'basic') {
+      // getCredentials throws when none are stored.
+      let authCredentials
+      try {
+        authCredentials = await tsCredentialService.getCredentials(session?.user?.id, endpointId as string)
+      } catch {
+        authCredentials = undefined
+      }
+      if (authCredentials?.username && authCredentials?.password) {
+        basicAuthHeader = Buffer.from(`${authCredentials.username}:${authCredentials.password}`).toString('base64')
       } else {
-        Logger.getLogger().error(serverResponse)
-        return res.status(500).json({ error: 'Invalid terminology server credentials' })
+        // Auth required but no credentials configured yet. This is a distinct
+        // state from "invalid/unreachable" — the endpoint just isn't ready to use.
+        return res.status(200).json({ status: 'no-credentials' })
       }
     }
-    return res.status(500).json({ error: 'No terminology server' })
 
-  } catch (e) {
-    Logger.getLogger().error(e)
-    return res.status(500).json({ error: 'Error occurred' })
+    // Build a request-scoped client. Do NOT mutate the shared TerminologyFhirClient
+    // singleton here — the settings page tests every endpoint concurrently, and a
+    // shared mutable client races (one request's base URL/auth clobbers another's).
+    const activeTerminologyClient = new FhirKitClient({
+      baseUrl: matchingEndpoint.address as string,
+      customHeaders: basicAuthHeader ? { Authorization: `Basic ${basicAuthHeader}` } : {}
+    })
+
+    Logger.getLogger().info(
+      `Testing endpoint ${endpointId} at ${matchingEndpoint.address} (auth: ${basicAuthHeader ? 'basic' : 'none'})`
+    )
+
+    const serverResponse = await activeTerminologyClient.request('/metadata')
+    // @ts-ignore
+    if (serverResponse?.resourceType == 'CapabilityStatement') {
+      return res.status(200).json({ status: 'ok' })
+    } else {
+      // @ts-ignore
+      Logger.getLogger().error(`Endpoint ${endpointId} returned non-CapabilityStatement: resourceType=${serverResponse?.resourceType}`)
+      return res.status(500).json({ error: 'Invalid terminology server response' })
+    }
+
+  } catch (e: any) {
+    // Log message + stack as strings — passing an Error object to pino is dropped
+    // by this app's custom messageFormat (only log.msg is printed).
+    Logger.getLogger().error(`test-terminology-endpoint failed for ${req.query.endpointId}: ${e?.message || e}`)
+    if (e?.stack) Logger.getLogger().error(`Stack: ${e.stack}`)
+    if (e?.response?.status) Logger.getLogger().error(`Upstream status: ${e.response.status}`)
+    return res.status(500).json({ error: e?.message || 'Error occurred' })
   }
 }
 

--- a/vsm-app/pages/api/test-terminology-endpoint.ts
+++ b/vsm-app/pages/api/test-terminology-endpoint.ts
@@ -5,7 +5,7 @@ import { VSMSession } from '@/helpers/rolesHelper'
 import handler from '@/helpers/server/handler'
 import FhirClient from '@/backend/clients/FhirCdrClient'
 import Logger from '@/helpers/server/logger'
-import { AUTHENTICATION_TYPE_URL } from '@/constants'
+import { AUTHENTICATION_TYPE_URL, AUTH_TYPE } from '@/constants'
 
 const testTermEndpoint = async (req: NextApiRequest, res: NextApiResponse, session: VSMSession) => {
   try {
@@ -33,11 +33,11 @@ const testTermEndpoint = async (req: NextApiRequest, res: NextApiResponse, sessi
       return res.status(404).json({ error: 'Terminology endpoint not found' })
     }
 
-    // Stored value is the option KEY ('basic' | 'none'), not the label — see
-    // TerminologyServerForm/types.ts (authenticationTypes) and the form's submit.
+    // Stored value is the option KEY (AUTH_TYPE.BASIC | AUTH_TYPE.NONE), not the
+    // label — shared via constants with the endpoint form and settings page.
     const authType = matchingEndpoint.extension?.find((ext: fhir4.Extension) => ext.url === AUTHENTICATION_TYPE_URL)?.valueString
     let basicAuthHeader: string | undefined
-    if (authType === 'basic') {
+    if (authType === AUTH_TYPE.BASIC) {
       // getCredentials throws when none are stored.
       let authCredentials
       try {

--- a/vsm-app/pages/api/test-terminology-endpoint.ts
+++ b/vsm-app/pages/api/test-terminology-endpoint.ts
@@ -62,10 +62,6 @@ const testTermEndpoint = async (req: NextApiRequest, res: NextApiResponse, sessi
       customHeaders: basicAuthHeader ? { Authorization: `Basic ${basicAuthHeader}` } : {}
     })
 
-    Logger.getLogger().info(
-      `Testing endpoint ${endpointId} at ${matchingEndpoint.address} (auth: ${basicAuthHeader ? 'basic' : 'none'})`
-    )
-
     const serverResponse = await activeTerminologyClient.request('/metadata')
     // @ts-ignore
     if (serverResponse?.resourceType == 'CapabilityStatement') {

--- a/vsm-app/pages/settings/index.tsx
+++ b/vsm-app/pages/settings/index.tsx
@@ -18,8 +18,14 @@ import { useRouter } from 'next/router'
 import { getAuthenticationTypeString } from '@/components/TerminologyServerForm'
 import { fetcher } from '@/utils'
 import { Box, Button, FormControl, Stack, TextField, Typography } from '@mui/material'
-import useSWR from 'swr'
+import useSWR, { mutate as globalMutate } from 'swr'
 import { Row as RowStyle } from '@/styles'
+
+// Revalidate the validity ping for an endpoint after its credentials change,
+// so the table Status cell re-tests instead of showing a stale result.
+const revalidateEndpointStatus = (endpointId?: string) => {
+  if (endpointId) globalMutate(`/api/test-terminology-endpoint?endpointId=${endpointId}`)
+}
 import { toast } from 'react-toastify'
 import { TerminologyServerCredentials } from '@/backend/model/TerminologyServerCredential'
 import { useSession } from 'next-auth/react'
@@ -106,7 +112,7 @@ const CredentialsSnippet = ({ shouldDisplay, isEditing, cancelEdit, onUpdate, us
   }
 }
 
-const AddEndpointForm = ({ availableEndpoints = [], closeForm }: any) => {
+const AddEndpointForm = ({ endpointId, closeForm }: { endpointId?: string; closeForm: () => void }) => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
 
@@ -157,9 +163,9 @@ const AddEndpointForm = ({ availableEndpoints = [], closeForm }: any) => {
         <Box>
           <Button onClick={() => closeForm()}> Cancel </Button>
           <Button
-            onClick={() => submitNewCredentials(availableEndpoints[0]?.id, username, password)}
+            onClick={() => endpointId && submitNewCredentials(endpointId, username, password)}
             sx={{ ml: '1rem' }}
-            disabled={!username.length || !password.length || !availableEndpoints?.[0]?.id}
+            disabled={!username.length || !password.length || !endpointId}
           >
             Update Credentials
           </Button>
@@ -169,10 +175,20 @@ const AddEndpointForm = ({ availableEndpoints = [], closeForm }: any) => {
   )
 }
 
-const ValidStatus = ({ isValid, isLoading }: { isValid: boolean, isLoading: boolean }) => {
+const ValidStatus = ({ isValid, isLoading, needsCredentials }: { isValid: boolean, isLoading: boolean, needsCredentials?: boolean }) => {
   if (isLoading) return (
     <p>Validating endpoint...</p>
   )
+
+  if (needsCredentials) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', color: 'var(--warning-medium)', whiteSpace: 'nowrap' }}>
+        <Typography style={{ color: 'inherit', whiteSpace: 'nowrap' }}>Needs credentials</Typography>
+        <WarningIcon style={{ color: 'inherit', marginLeft: '.2rem', marginBottom: '.1rem', width: '1.1rem' }} />
+      </div>
+    )
+  }
+
   const inner = isValid ? (
     <>
       <Typography style={{ color: 'inherit' }}>Valid</Typography>
@@ -193,51 +209,46 @@ const ValidStatus = ({ isValid, isLoading }: { isValid: boolean, isLoading: bool
 }
 
 const EndpointStatusCell = ({ id, onValidityChange }: { id: string, onValidityChange: (id: string, isValid: boolean) => void }) => {
-  const { isEndpointValid, pingLoading } = useTestTermEndpoint({ endpointId: id })
+  const { isEndpointValid, needsCredentials, pingLoading } = useTestTermEndpoint({ endpointId: id })
   useEffect(() => {
-    if (!pingLoading) onValidityChange(id, isEndpointValid)
+    // "Needs credentials" is a config-todo, not an invalid/unreachable endpoint —
+    // don't let it trip the "one or more endpoints are invalid" banner.
+    if (!pingLoading) onValidityChange(id, isEndpointValid || needsCredentials)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, isEndpointValid, pingLoading])
-  return <ValidStatus isValid={isEndpointValid} isLoading={pingLoading} />
+  }, [id, isEndpointValid, needsCredentials, pingLoading])
+  return <ValidStatus isValid={isEndpointValid} needsCredentials={needsCredentials} isLoading={pingLoading} />
 }
 
 const CredentialsItem = (currentServerData: any) => {
   const [showCredentialSet, setShowCredentialSet] = useState(new Set())
   const [showEditSet, setShowEditSet] = useState(new Set())
-  const {data, currentCredentialsByServerId, currentCredentialsByServerIdLoading, reloadCurrentCredentials} = currentServerData
+  const {data, currentCredentialsByServerId, credentialsByServerIdLoading, reloadCurrentCredentials} = currentServerData
   const [isAdding, setIsAdding] = useState(false)
-  
-  const { data: allCurrentEndpoints = null, isLoading: endpointsLoading, mutate: reloadCurrentEndpoints } = useSWR('/api/endpoint', fetcher)
 
   const refetchData = () => {
     reloadCurrentCredentials()
-    reloadCurrentEndpoints()
   }
 
-  const [availableEndpoints, credentials] = useMemo(() => {
-    const availEnd = [] as EndpointDetails[]
+  // Derive this row's credential from the row data itself (data is the endpoint
+  // for this expandable row) plus the credentials the parent already fetched.
+  // No separate /api/endpoint fetch — that caused a pagination mismatch and
+  // stale-memo bugs.
+  const credentials = useMemo(() => {
     const creds = [] as ({ username: string; password: string; } & EndpointDetails)[]
-    allCurrentEndpoints?.endpoints
-    ?.filter((e: any) => e?.id === data?.id)
-    ?.forEach((endpoint: fhir4.Endpoint) => {
-      const foundCred = currentCredentialsByServerId?.find((cred: any) => cred.terminologyServerId === endpoint.id)
-      const baseEndpoint = {
-        id: endpoint.id,
-        name: endpoint.name,
-        address: endpoint.address
-      } as EndpointDetails
+    if (data?.id) {
+      const foundCred = currentCredentialsByServerId?.find((cred: any) => cred.terminologyServerId === data.id)
       if (foundCred) {
         creds.push({
-          ...baseEndpoint,
+          id: data.id,
+          name: data.name,
+          address: data.address,
           username: foundCred.username,
           password: foundCred.password
         })
-      } else {
-        availEnd.push(baseEndpoint)
       }
-    })
-    return [availEnd, creds]
-  }, [currentCredentialsByServerId, allCurrentEndpoints])
+    }
+    return creds
+  }, [currentCredentialsByServerId, data?.id, data?.name, data?.address])
 
     const {
     isEndpointValid,
@@ -250,7 +261,7 @@ const CredentialsItem = (currentServerData: any) => {
 
   useEffect(() => {
     pingMutate('/api/test-terminology-endpoint')
-  }, [credentials?.[0]])
+  }, [credentials?.[0]?.id])
 
 
   const updateCredential = async (id: string, username: string, password: string) => {
@@ -268,6 +279,7 @@ const CredentialsItem = (currentServerData: any) => {
       if (result.ok) {
         toast.success('Credential updated successfully')
         await reloadCurrentCredentials()
+        revalidateEndpointStatus(id)
         return
       } else {
         const json = await result.json()
@@ -293,6 +305,7 @@ const CredentialsItem = (currentServerData: any) => {
 
       if (result.ok) {
         toast.success('Credential deleted successfully')
+        revalidateEndpointStatus(id)
       } else {
         const json = await result.json()
         console.error(json)
@@ -306,7 +319,7 @@ const CredentialsItem = (currentServerData: any) => {
 
   const isOdd = data?.index % 2 === 0
 
-  if (currentCredentialsByServerIdLoading || endpointsLoading) {
+  if (credentialsByServerIdLoading) {
     return <LoadingIndicator />
   }
 
@@ -314,7 +327,6 @@ const CredentialsItem = (currentServerData: any) => {
 
   const reload = async () => {
     reloadCurrentCredentials()
-    reloadCurrentEndpoints()
   }
 
   if (isOpenEndpoint) {
@@ -342,10 +354,10 @@ const CredentialsItem = (currentServerData: any) => {
       )}
       {isAdding && (
         <AddEndpointForm
-          isOdd={isOdd}
-          availableEndpoints={availableEndpoints}
+          endpointId={data?.id}
           closeForm={() => {
             refetchData()
+            revalidateEndpointStatus(data?.id)
             setIsAdding(false)
           }}
         />
@@ -502,9 +514,12 @@ const TerminologyEndpoints: NextPage = () => {
 
   const [endpointValidity, setEndpointValidity] = useState<Record<string, boolean>>({})
 
+  // Only flag endpoints that currently exist and have been explicitly tested as
+  // invalid. Endpoints not yet tested (undefined) shouldn't trip the banner, and
+  // stale validity entries for deleted endpoints must be ignored.
   const anyEndpointInvalid = useMemo(
-    () => Object.values(endpointValidity).some((isValid) => !isValid),
-    [endpointValidity]
+    () => data.some((ep) => ep.id != null && endpointValidity[ep.id] === false),
+    [data, endpointValidity]
   )
 
   const columns: TableColumn<fhir4.Endpoint>[] = useMemo(
@@ -549,7 +564,7 @@ const TerminologyEndpoints: NextPage = () => {
       {
         name: 'Status',
         sortable: false,
-        maxWidth: '8rem',
+        minWidth: '11rem',
         cell: (row: fhir4.Endpoint) => (
           <EndpointStatusCell
             id={row.id!}

--- a/vsm-app/pages/settings/index.tsx
+++ b/vsm-app/pages/settings/index.tsx
@@ -20,19 +20,19 @@ import { fetcher } from '@/utils'
 import { Box, Button, FormControl, Stack, TextField, Typography } from '@mui/material'
 import useSWR, { mutate as globalMutate } from 'swr'
 import { Row as RowStyle } from '@/styles'
-
-// Revalidate the validity ping for an endpoint after its credentials change,
-// so the table Status cell re-tests instead of showing a stale result.
-const revalidateEndpointStatus = (endpointId?: string) => {
-  if (endpointId) globalMutate(`/api/test-terminology-endpoint?endpointId=${endpointId}`)
-}
 import { toast } from 'react-toastify'
 import { TerminologyServerCredentials } from '@/backend/model/TerminologyServerCredential'
 import { useSession } from 'next-auth/react'
 import { VSMSession } from '@/helpers/rolesHelper'
 import { useTestTermEndpoint } from '@/hooks/useTestTermEndpoint'
 import { apiFetch } from '@/utils'
-import { ARTIFACT_ROUTE_URL } from '@/constants'
+import { ARTIFACT_ROUTE_URL, AUTH_TYPE } from '@/constants'
+
+// Revalidate the validity ping for an endpoint after its credentials change,
+// so the table Status cell re-tests instead of showing a stale result.
+const revalidateEndpointStatus = (endpointId?: string) => {
+  if (endpointId) globalMutate(`/api/test-terminology-endpoint?endpointId=${endpointId}`)
+}
 
 const Col = styled.div`
   display: flex;
@@ -323,7 +323,7 @@ const CredentialsItem = (currentServerData: any) => {
     return <LoadingIndicator />
   }
 
-  const isOpenEndpoint = getAuthenticationTypeString(data?.extension || []) === 'none'
+  const isOpenEndpoint = getAuthenticationTypeString(data?.extension || []) === AUTH_TYPE.NONE
 
   const reload = async () => {
     reloadCurrentCredentials()

--- a/vsm-app/pages/settings/index.tsx
+++ b/vsm-app/pages/settings/index.tsx
@@ -16,6 +16,7 @@ import { EndpointResponse } from '../api/endpoint'
 import { PaginationState } from '@/components/Program/ProgramsTab'
 import { useRouter } from 'next/router'
 import { getAuthenticationTypeString } from '@/components/TerminologyServerForm'
+import { authenticationTypes } from '@/components/TerminologyServerForm/types'
 import { fetcher } from '@/utils'
 import { Box, Button, FormControl, Stack, TextField, Typography } from '@mui/material'
 import useSWR, { mutate as globalMutate } from 'swr'
@@ -546,7 +547,10 @@ const TerminologyEndpoints: NextPage = () => {
       },
       {
         name: 'Authentication',
-        selector: (row: fhir4.Endpoint) => getAuthenticationTypeString(row.extension || []) || '',
+        selector: (row: fhir4.Endpoint) => {
+          const authType = getAuthenticationTypeString(row.extension || [])
+          return (authType && authenticationTypes[authType as keyof typeof authenticationTypes]) || authType || ''
+        },
         sortable: false,
         maxWidth: '8rem',
         wrap: true

--- a/vsm-app/tests/api/test-terminology-endpoint.spec.ts
+++ b/vsm-app/tests/api/test-terminology-endpoint.spec.ts
@@ -1,0 +1,124 @@
+import { createMocks } from 'node-mocks-http'
+import { AUTHENTICATION_TYPE_URL, AUTH_TYPE } from '@/constants'
+
+jest.mock('next-auth', () => jest.fn())
+jest.mock('next-auth/next', () => ({
+  getServerSession: jest.fn().mockImplementation(() => ({
+    user: { id: 'user-123', roles: ['admin'], email: 'admin@example.com' }
+  }))
+}))
+
+jest.mock('../../backend/clients/FhirCdrClient', () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn() }
+}))
+
+jest.mock('../../backend/services/TsCredentialService', () => ({
+  tsCredentialService: { getCredentials: jest.fn() }
+}))
+
+// Keep the factory self-contained — ESM imports are hoisted above any const, so
+// referencing an outer variable here would hit the temporal dead zone.
+jest.mock('fhir-kit-client', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+import handler from '@/pages/api/test-terminology-endpoint'
+import FhirClient from '@/backend/clients/FhirCdrClient'
+import { tsCredentialService } from '@/backend/services/TsCredentialService'
+import FhirKitClient from 'fhir-kit-client'
+
+const mockFhirKitClientCtor = FhirKitClient as unknown as jest.Mock
+const mockRequest = jest.fn()
+const mockRead = jest.fn()
+
+const makeEndpoint = (overrides: Partial<fhir4.Endpoint> = {}, authType?: string): fhir4.Endpoint => ({
+  resourceType: 'Endpoint',
+  id: '1001',
+  status: 'active',
+  connectionType: { code: 'fhir' },
+  payloadType: [],
+  address: 'https://tx.example.org/r4',
+  ...(authType !== undefined && {
+    extension: [{ url: AUTHENTICATION_TYPE_URL, valueString: authType }]
+  }),
+  ...overrides
+})
+
+const capabilityStatement = { resourceType: 'CapabilityStatement' }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(FhirClient.getInstance as jest.Mock).mockReturnValue({ read: mockRead })
+  mockFhirKitClientCtor.mockImplementation(() => ({ request: mockRequest }))
+})
+
+const callHandler = async (query: Record<string, string>) => {
+  const { req, res } = createMocks({ method: 'GET', query })
+  await handler(req as any, res as any)
+  return res
+}
+
+describe('GET /api/test-terminology-endpoint', () => {
+  test('returns 400 when endpointId is missing', async () => {
+    const res = await callHandler({})
+    expect(res._getStatusCode()).toBe(400)
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+
+  test('returns 404 when the endpoint does not exist (read throws)', async () => {
+    mockRead.mockRejectedValue(new Error('not found'))
+    const res = await callHandler({ endpointId: '9999' })
+    expect(res._getStatusCode()).toBe(404)
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  test('reads the endpoint by id, not via a windowed search', async () => {
+    mockRead.mockResolvedValue(makeEndpoint({}, AUTH_TYPE.NONE))
+    mockRequest.mockResolvedValue(capabilityStatement)
+    await callHandler({ endpointId: '1001' })
+    expect(mockRead).toHaveBeenCalledWith({ resourceType: 'Endpoint', id: '1001' })
+  })
+
+  test('no-auth endpoint that returns a CapabilityStatement is valid', async () => {
+    mockRead.mockResolvedValue(makeEndpoint({}, AUTH_TYPE.NONE))
+    mockRequest.mockResolvedValue(capabilityStatement)
+    const res = await callHandler({ endpointId: '1001' })
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData()).toEqual({ status: 'ok' })
+    // unauthenticated ping — no Authorization header
+    expect(mockFhirKitClientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://tx.example.org/r4', customHeaders: {} })
+    )
+  })
+
+  test('basic-auth endpoint with no stored credentials returns no-credentials (does not ping)', async () => {
+    mockRead.mockResolvedValue(makeEndpoint({}, AUTH_TYPE.BASIC))
+    ;(tsCredentialService.getCredentials as jest.Mock).mockRejectedValue(new Error('no creds'))
+    const res = await callHandler({ endpointId: '1001' })
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData()).toEqual({ status: 'no-credentials' })
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  test('basic-auth endpoint with credentials pings with a Basic auth header', async () => {
+    mockRead.mockResolvedValue(makeEndpoint({}, AUTH_TYPE.BASIC))
+    ;(tsCredentialService.getCredentials as jest.Mock).mockResolvedValue({ username: 'user', password: 'pass' })
+    mockRequest.mockResolvedValue(capabilityStatement)
+    const res = await callHandler({ endpointId: '1001' })
+    expect(res._getStatusCode()).toBe(200)
+    expect(res._getJSONData()).toEqual({ status: 'ok' })
+    const expectedHeader = `Basic ${Buffer.from('user:pass').toString('base64')}`
+    expect(mockFhirKitClientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ customHeaders: { Authorization: expectedHeader } })
+    )
+  })
+
+  test('returns 500 when the server response is not a CapabilityStatement', async () => {
+    mockRead.mockResolvedValue(makeEndpoint({}, AUTH_TYPE.NONE))
+    mockRequest.mockResolvedValue({ resourceType: 'OperationOutcome' })
+    const res = await callHandler({ endpointId: '1001' })
+    expect(res._getStatusCode()).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a cluster of bugs in the terminology endpoint settings page (add/update/delete endpoints + credentials and per-endpoint validation). They shared a handful of root causes: windowed searches used where direct lookups were correct, object-identity churn feeding React effects, a shared mutable client raced under concurrent requests, and a label-vs-key string mismatch on the auth type.

### Credential management (pages/settings/index.tsx)
  - AddEndpointForm now takes the row's endpointId directly and gates/submits on it, instead of indexing into a separately-fetched, filtered availableEndpoints[0]. Fixes the "Update Credentials" button staying disabled after entering credentials, and #683 ("credentials edit only shows for the last entry in the table").
  - CredentialsItem derives its credential from the row data + the parent credentials SWR with stable primitive memo deps, and no longer does its own unpaginated /api/endpoint fetch (which mismatched the table's paginated fetch). Fixed a loading prop-name mismatch (credentialsByServerIdLoading) that left the loading guard dead.
  - Fixed an infinite re-render/refetch loop: the validity-ping effect and credentials memo keyed on object refs that the parent regenerates every render ({...d, index}); switched to stable primitives (data?.id, credentials?.[0]?.id).
  - After credential add/update/delete, the endpoint's validation is re-run (SWR mutate of the test key) so status refreshes instead of going stale.
  - The "invalid/unreachable" banner now only counts endpoints currently in the list that explicitly failed (ignores deleted-endpoint leftovers and not-yet-tested endpoints).
  - Authentication column shows friendly labels ("Basic Authentication" / "No Authentication") instead of the raw stored key.

### Endpoint validation (pages/api/test-terminology-endpoint.ts, hooks/useTestTermEndpoint.ts)
  - Reads the endpoint by id (FhirClient.read) instead of an unfiltered, unpaginated search().find() that silently failed for any endpoint outside the server's default result window - notably a just-created one, which was therefore perpetually "invalid".
  - Builds a request-scoped FhirKitClient for the /metadata ping instead of mutating the shared TerminologyFhirClient singleton, which raced under the page's concurrent per-endpoint pings (one request's base URL/auth clobbering another's) and mismarked reachable endpoints invalid.
  - Compares auth type against the stored value (AUTH_TYPE.BASIC), not the label 'Basic Authentication'. The mismatch meant every endpoint was treated as no-auth, so credential-protected endpoints (e.g. VSAC) skipped the credential path and showed "valid" via a public /metadata ping before any credentials were entered.
  - Adds a third validation state: a Basic-Auth endpoint with no stored credentials returns { status: 'no-credentials' }, surfaced as Needs credentials (amber) - distinct from green Valid and from the "invalid/unreachable" banner. 
  - Surfaces real errors in logs (message/stack as strings; the prior logger.error(errorObject) was dropped by the app's pino messageFormat).
  
### Hardening (constants.ts, components/TerminologyServerForm/types.ts)
  - Centralized the auth-type keys in a shared AUTH_TYPE constant used by the form, the settings page, and the validation route - removing the duplicated 'basic'/'none' literals that allowed the label-vs-key mismatch in the first place.
  
### Tests (tests/api/test-terminology-endpoint.spec.ts)
  - 7 API-route tests covering the regressions: missing id -> 400; not found -> 404 (guards read-by-id vs the old windowed search); reads by id with correct args; no-auth + CapabilityStatement -> valid (unauthenticated); basic-auth + no creds -> no-credentials and no ping (guards the third state + auth-type key comparison); basic-auth + creds -> pings with a Basic header; non-CapabilityStatement -> 500.
  
## Test plan

  - [x] No-auth endpoint (reachable) -> Valid.
  - [x] Basic-Auth endpoint, no creds -> Needs credentials (not Valid, no error banner).
  - [x] Add creds -> status auto-refreshes to Valid; "Update Credentials" enables as soon as both fields are filled.
  - [x] Add creds to a non-last endpoint in a multi-endpoint list -> editor displays and saves against the correct endpoint (#683 regression).
  - [x] 3+ endpoints -> no infinite GET /api/test-terminology-endpoint loop.
  - [x] Delete an endpoint -> no lingering "invalid or unreachable" banner from it.
  - [x] Unreachable / auth-rejecting URL -> Invalid + banner.
  - [x] Authentication column shows friendly labels.
  - [x] npx jest tests/api/test-terminology-endpoint (7 tests) green; npx tsc --noEmit clean aside from the pre-existing tests/worker/DependencyQueue.spec.ts Buffer error.

Closes #683