### PR TITLE
Ensure only related leafs are displayed for VSM authored Groupers

### DIFF
--- a/vsm-app/components/ValueSetDetailsTables.tsx
+++ b/vsm-app/components/ValueSetDetailsTables.tsx
@@ -352,9 +352,11 @@ const ValueSetDetailsTables = ({
   }
 
   const isVsmGrouper = isGrouperValueSet && isVSMOwnedVSet(currentValueSet)
+  // For VSM Groupers, filter programValueSets so only grouper specific leafs are displayed.
   const definitionColumnsAndData = generateColumnsAndData({
     currentVs: currentValueSet,
-    valueSetsInVsmGrouper: isVsmGrouper ? programValuesets?.data : null
+    valueSetsInVsmGrouper: isVsmGrouper ? programValuesets?.data?.filter((item: DataItem) =>
+      item.groups?.some((g) => g.id === currentValueSet.id || g.url === currentValueSet.url)): null
   })
 
   let expansionData = expansion?.contains


### PR DESCRIPTION
Currently, when you create a new grouper and add some ValueSets, you expect the created grouper to show the selected ValueSets - in reality it shows every ValueSet in the entire program (including those from other groupers).

This change applies filtering to ensure that only leafs associated with the related VSM authored Grouper are displayed.