### PR TITLE
Update VS Search status SearchParams/filter

### DIFF
--- a/vsm-app/pages/api/valueset/search.ts
+++ b/vsm-app/pages/api/valueset/search.ts
@@ -90,6 +90,7 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
       case 'title':
         searchParams = {
           'title:contains': search,
+          status: 'active,retired',
           _count: count,
           _offset: typeof offset === 'string' && offset
         }
@@ -154,6 +155,7 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
             )
               ?.filter(is.promiseFulfilled)
               ?.map((val) => val.value)
+              ?.filter((vs) => vs.status === 'active' || vs.status === 'retired')
 
             const successfulOIDs = responseInfo?.valueSets?.map((v) => v?.id)
             responseInfo.total = successfulOIDs.length
@@ -191,7 +193,8 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
         // http://cts.nlm.nih.gov/fhir/ValueSet?status=active
         // VSAC also does not respect _sort
         searchParams = {
-          url: search
+          url: search,
+          status: 'active,retired',
         } as SearchParams
 
         if (typeof offset === 'string') {

--- a/vsm-app/pages/api/valueset/search.ts
+++ b/vsm-app/pages/api/valueset/search.ts
@@ -90,7 +90,6 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
       case 'title':
         searchParams = {
           'title:contains': search,
-          status: 'active',
           _count: count,
           _offset: typeof offset === 'string' && offset
         }
@@ -155,7 +154,6 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
             )
               ?.filter(is.promiseFulfilled)
               ?.map((val) => val.value)
-              ?.filter((vs) => vs.status === 'active')
 
             const successfulOIDs = responseInfo?.valueSets?.map((v) => v?.id)
             responseInfo.total = successfulOIDs.length
@@ -193,8 +191,7 @@ const searchValueSet = async (req: NextApiRequest, res: NextApiResponse, session
         // http://cts.nlm.nih.gov/fhir/ValueSet?status=active
         // VSAC also does not respect _sort
         searchParams = {
-          url: search,
-          status: 'active'
+          url: search
         } as SearchParams
 
         if (typeof offset === 'string') {


### PR DESCRIPTION
VSAC auto-transitions ValueSets to 'retired' status if they hadn’t been explicitly reviewed by a maintainer. Many of the active ValueSets used in eRSD had that happen to them. 

VSM currently only returns ValueSets which have an 'active' status.

This changes updates that logic to allow the addition of ValueSets with the 'retired' status.