### PR TITLE
Fix issues with Provisional CodeSystems & ValueSets

### DIFF
--- a/vsm-app/pages/api/valueset/provisional/index.ts
+++ b/vsm-app/pages/api/valueset/provisional/index.ts
@@ -102,12 +102,13 @@ const createOrEditProvisionalValueSet = async (req: ReqInfo, res: NextApiRespons
     const resourcesToSaveLast = [] as BuilderItem[]
 
     for (const systemUrl of systemUrls) {
-      // if provisional code system already exists, update the codesystem with any new items
+      // if provisional code system already exists, update the codesystem with any new items.
+      // provisional code systems are indexed via provisional-cs-by-base-url. Use this to prevent duplicate creation.
       const existingCS = await FhirClient.getInstance().search({
         resourceType: 'CodeSystem',
         searchParams: {
           version: 'PROVISIONAL',
-          system: systemUrl
+          'provisional-cs-by-base-url': systemUrl
         }
       })
 

--- a/vsm-app/pages/provisional/valueset/index.tsx
+++ b/vsm-app/pages/provisional/valueset/index.tsx
@@ -97,7 +97,8 @@ interface ExistingCodesProps {
   setClearStagedCodes: BooleanSetState
   toggledClearProvCodeRows: boolean
   setToggledClearProvCodeRows: BooleanSetState
-  systemName: string
+  systemName: string,
+  systemUrl: string, //baseUrl shared by existing and new provisional codes
   codeSystem: fhir4.CodeSystem
   handleAddCodes: (codes: CodesBySystem, action: 'add' | 'remove') => void
 }
@@ -122,7 +123,7 @@ export const findProgramByProvisionalLeaf = (leafUrlToFind: string, provisionalC
   return programIds
 }
 
-const ExistingCodesTable = ({ systemName, codeSystem, handleAddCodes, toggledClearProvCodeRows, setToggledClearProvCodeRows, setClearStagedCodes }: ExistingCodesProps) => {
+const ExistingCodesTable = ({ systemName, systemUrl, codeSystem, handleAddCodes, toggledClearProvCodeRows, setToggledClearProvCodeRows, setClearStagedCodes }: ExistingCodesProps) => {
   const [selectedRows, setSelectedRows] = useState<CodeInfo[]>([])
 
   const handleChangeSelectedRows = (r: SelectedRowsInExistingProvCodes) => {
@@ -132,7 +133,7 @@ const ExistingCodesTable = ({ systemName, codeSystem, handleAddCodes, toggledCle
   const handleClear = () => setToggledClearProvCodeRows((t: boolean) => !t)
 
   const handleAdd = () => {
-    handleAddCodes({ [codeSystem.url!]: [...selectedRows] }, 'add')
+    handleAddCodes({ [systemUrl]: [...selectedRows] }, 'add')
     handleClear()
   }
 
@@ -468,7 +469,11 @@ const ProvisionalVSEdit = () => {
     }
     const keys = Object.keys(codesBySystemToAdd) || []
     keys.forEach(k => {
-      const name = csSelectOptions.find(o => o.value === k)?.label as string
+      // if a provisional CS exists for a given base URL, use its name
+      const name = (
+          provisionalCS?.find((cs: fhir4.CodeSystem) => cs?.extension?.find(ext => ext.valueUri === k))?.name
+          ?? csSelectOptions.find(o => o.value === k)?.label
+      ) as string
       return codesBySystemToAdd[k].forEach(dataItem => {
         result.push({ system: k, name, ...dataItem })
       })
@@ -772,6 +777,7 @@ const ProvisionalVSEdit = () => {
                     setToggledClearProvCodeRows={setToggledClearProvCodeRows}
                     toggledClearProvCodeRows={toggledClearProvCodeRows}
                     systemName={selectedCodeSystemBase?.label!}
+                    systemUrl={selectedCodeSystemBase?.value!}
                     codeSystem={existingProvisionalCs?.provisionalCS?.find((c: fhir4.CodeSystem | undefined) => c?.extension?.find(ext => ext.valueUri === selectedCodeSystemBase?.value))!}
                     handleAddCodes={handleUpdateStaging}
                     setClearStagedCodes={setClearStagedCodes}


### PR DESCRIPTION
If I create a provisional ValueSet using an existing code from a provisional CodeSystem and I add a new code (as part of the ValueSet creation flow) then the app tries to create a new instance of the CodeSystem, rather than adding the newly defined code to the existing CodeSystem.

 The staging table also doesn’t show the system value for selected existing provisional codes.

This fix ensures that existing provisional Code Systems are retrieved correctly, to prevent attempts at creating duplicates. It also ensures that the correct name/system is populated into the staging table.