### PR TITLE
Update PackageQueue to handle async processing if supported

### DIFF
--- a/vsm-app/worker/PackageQueue.ts
+++ b/vsm-app/worker/PackageQueue.ts
@@ -13,83 +13,6 @@ import { convertBundleToCSVHelper } from '@/helpers/convertBundleToCSVHelper'
 
 const PackageQueue = new Queue('exportProgram', QUEUE_OPTIONS)
 
-const convertV2toV1 = async (v2: fhir4.Bundle, format: 'json' | 'xml', planDefinition?: fhir4.PlanDefinition, targetVersion?: string) => {
-  if (!v2.entry) {
-    throw 'Empty bundle returned from server'
-  }
-  Logger.getLogger().info('Generating v2 to v1 transform for download')
-
-  const planDefResourceIndex = v2.entry.findIndex((e: fhir4.BundleEntry) => e.resource?.resourceType === 'PlanDefinition')
-  const planDefFromV2Exist = planDefResourceIndex != null && planDefResourceIndex > -1
-
-  // if planDefinition is provided in the request, and not present then add it to bundle entry
-  if (!planDefFromV2Exist && planDefinition != null) {
-    v2.entry.push({
-      fullUrl: planDefinition?.url,
-      resource: planDefinition
-    })
-    // if planDefinition is provided in the request, use it to replace the one from the v2 package response
-  } else if (planDefFromV2Exist && planDefinition != null) {
-    v2.entry[planDefResourceIndex].resource = planDefinition
-  } else if (!planDefFromV2Exist && planDefinition == null) {
-    const errorMessage = 'No PlanDefinition resource found in package response nor was uploaded as part of the request'
-    Logger.getLogger().error(errorMessage)
-    throw errorMessage
-  }
-  const v1BundleBody: fhir4.Parameters = {
-    resourceType: 'Parameters',
-    parameter: [
-      {
-        name: 'bundle',
-        resource: v2
-      }
-    ]
-  }
-
-  if (targetVersion && targetVersion?.length > 0) {
-    v1BundleBody.parameter?.push({
-      name: 'targetVersion',
-      valueString: targetVersion
-    })
-  }
-
-  return f(`${FhirClient.getInstance().baseUrl}/$ersd-v2-to-v1-transform?_format=${format}`, {
-    body: JSON.stringify(v1BundleBody),
-    method: 'POST',
-    dispatcher: new Agent({
-      connectTimeout: 24 * 60 * 60 * 1000,
-      headersTimeout: 24 * 60 * 60 * 1000,
-      keepAliveTimeout: 24 * 60 * 60 * 1000,
-      keepAliveMaxTimeout: 24 * 60 * 60 * 1000
-    }),
-    // @ts-ignore
-    headers: {
-      'Content-Type': 'application/fhir+json',
-      // should be Basic Auth creds
-      ...FhirClient.getInstance().customHeaders
-    }
-  })
-    .then(async (r) => {
-      if (format === 'json') {
-        try {
-          return (await r.json()) as fhir4.Bundle | fhir4.OperationOutcome
-        } catch (e) {
-          return await r.text()
-        }
-      } else {
-        return await r.text()
-      }
-    })
-    .catch((err) => {
-      logSimpleError(err)
-      if ('cause' in err) {
-        throw err.cause
-      } else {
-        throw err
-      }
-    })
-}
-
 const validatePackage = async (pkgBundle: fhir4.Bundle | string) => {
   let parameters: string
   // string means XML
@@ -147,87 +70,65 @@ const validatePackage = async (pkgBundle: fhir4.Bundle | string) => {
 
 PackageQueue.process(async function (job: any, done) {
   Logger.getLogger().info('Begin Export Operation Job')
-  const { data, programId, planDefinition, targetVersion, userId, convertToCSV } = job.data
+  const { data, programId, userId, convertToCSV } = job.data
   job.progress(1)
   const parameters = await addTerminologyEndpointToParameters({parameters: data?.parameters, userId})
 
-  // conversion to CSV happens at the end of processing, 
+  // conversion to CSV happens at the end of processing,
   // use JSON for the actual work until the end, then convert the JSON to CSV
-  const userDesiredFormat = data?.json || convertToCSV? 'json' : 'xml'
-  const useV1 = !data?.useV2
+  const userDesiredFormat = data?.json || convertToCSV ? 'json' : 'xml'
   const cache = await Cache.getInstance()
   const cacheKey = `user:${userId}:job:${job.id}`
   try {
-    let currentFormat = useV1 ? 'json' : userDesiredFormat // force json for v1 so we can pass it back to the server to convert to v2
     Logger.getLogger().info('Exporting program: ' + programId)
-    const url = `${FhirClient.getInstance().baseUrl}/Library/${programId as string}/$package?_format=${currentFormat}`
-    Logger.getLogger().debug(`Exporting program ${programId} with parameters: ${JSON.stringify(parameters)}`)
-    let response = await f(url, {
-      body: JSON.stringify(parameters),
-      method: 'POST',
-      dispatcher: new Agent({
-        connectTimeout: 24 * 60 * 60 * 1000,
-        headersTimeout: 24 * 60 * 60 * 1000,
-        keepAliveTimeout: 24 * 60 * 60 * 1000,
-        keepAliveMaxTimeout: 24 * 60 * 60 * 1000
-      }),
-      // @ts-ignore
-      headers: {
-        'Content-Type': 'application/fhir+json',
-        ...FhirClient.getInstance().customHeaders
-      }
-    })
-      .then(async (r) => {
-        if (!r.ok) {
-          throw new Error(`HTTP error: ${r.status} ${r.statusText}`);
-        }
-        if (currentFormat === 'json') {
-          try {
-            return (await r.json()) as fhir4.Bundle | fhir4.OperationOutcome
-          } catch (e) {
-            return await r.text()
-          }
-        } else {
-          return await r.text()
+    const url = `${FhirClient.getInstance().baseUrl}/Library/${programId as string}/$package?_format=${userDesiredFormat}`
+    let initialResponse
+    try {
+      initialResponse = await f(url, {
+        body: JSON.stringify(parameters),
+        method: 'POST',
+        dispatcher: new Agent({
+          connectTimeout: 24 * 60 * 60 * 1000,
+          headersTimeout: 24 * 60 * 60 * 1000,
+          keepAliveTimeout: 24 * 60 * 60 * 1000,
+          keepAliveMaxTimeout: 24 * 60 * 60 * 1000
+        }),
+        // @ts-ignore
+        headers: {
+          'Content-Type': 'application/fhir+json',
+          'Prefer': 'respond-async',
+          ...FhirClient.getInstance().customHeaders
         }
       })
-      .catch((err) => {
-        Logger.getLogger().error('Export error details:');
-        Logger.getLogger().error(`Message: ${err?.message}`);
-        Logger.getLogger().error(`Name: ${err?.name}`);
-        Logger.getLogger().error(err?.stack);
+    } catch (err: any) {
+      Logger.getLogger().error('Export error details:')
+      Logger.getLogger().error(`Message: ${err?.message}`)
+      Logger.getLogger().error(`Name: ${err?.name}`)
+      Logger.getLogger().error(err?.stack)
+      logSimpleError(err)
+      throw 'cause' in err ? err.cause : err
+    }
 
-        logSimpleError(err)
-        if ('cause' in err) {
-          throw err.cause
-        } else {
-          throw err
+    let response: fhir4.Bundle | fhir4.OperationOutcome | string
+    if (initialResponse.status === 202) {
+      const statusUrl = initialResponse.headers.get('Content-Location')
+      if (!statusUrl) {
+        throw new Error('Server returned 202 but no Content-Location header for async polling')
+      }
+      Logger.getLogger().info(`Async $package accepted, polling status at: ${statusUrl}`)
+      response = await pollAsyncPackage(statusUrl, userDesiredFormat)
+    } else if (initialResponse.ok) {
+      if (userDesiredFormat === 'json') {
+        try {
+          response = (await initialResponse.json()) as fhir4.Bundle | fhir4.OperationOutcome
+        } catch (e) {
+          response = await initialResponse.text()
         }
-      })
-    if (useV1) {
-      if (typeof response === 'string') {
-        throw new Error('Got string (XML?) response but expected FHIR JSON')
+      } else {
+        response = await initialResponse.text()
       }
-      if (response.resourceType === 'OperationOutcome') {
-        job.progress(100)
-        const errorMsg = response?.issue?.map((e) => e?.diagnostics!).join(', ') || 'Error encountered while packaging V1'
-        Logger.getLogger().error(errorMsg)
-        await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', errorMsg)
-        return done(null, { error: errorMsg })
-      }
-      try {
-        Logger.getLogger().info('Converting V2 to V1 for export program: ' + programId)
-        response = await convertV2toV1(
-          response,
-          (currentFormat = userDesiredFormat), // reset to actual format for v1
-          planDefinition,
-          targetVersion
-        )
-      } catch (error: any) {
-        Logger.getLogger().error(error)
-        await cache.hset(cacheKey, 'status', JOB_STATUS.FAILED, 'error', error)
-        return done(null, { error })
-      }
+    } else {
+      throw new Error(`HTTP error: ${initialResponse.status} ${initialResponse.statusText}`)
     }
     if (
       (typeof response !== 'string' && response.resourceType === 'OperationOutcome') ||
@@ -263,5 +164,46 @@ PackageQueue.process(async function (job: any, done) {
     return done(null, { error: errorMsg })
   }
 })
+
+const ASYNC_POLL_INTERVAL_MS = 10000
+const ASYNC_MAX_POLL_ATTEMPTS = 720 // 2 hours at 10s intervals
+
+const pollAsyncPackage = async (statusUrl: string, format: string): Promise<fhir4.Bundle | fhir4.OperationOutcome | string> => {
+  for (let attempt = 0; attempt < ASYNC_MAX_POLL_ATTEMPTS; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, ASYNC_POLL_INTERVAL_MS))
+
+    const pollResponse = await f(statusUrl, {
+      method: 'GET',
+      dispatcher: new Agent({
+        connectTimeout: 24 * 60 * 60 * 1000,
+        headersTimeout: 24 * 60 * 60 * 1000,
+        keepAliveTimeout: 24 * 60 * 60 * 1000,
+        keepAliveMaxTimeout: 24 * 60 * 60 * 1000
+      }),
+      headers: { ...FhirClient.getInstance().customHeaders }
+    })
+
+    if (pollResponse.status === 200) {
+      Logger.getLogger().info('Async $package operation complete')
+      if (format === 'json') {
+        try {
+          return (await pollResponse.json()) as fhir4.Bundle | fhir4.OperationOutcome
+        } catch (e) {
+          return await pollResponse.text()
+        }
+      } else {
+        return await pollResponse.text()
+      }
+    } else if (pollResponse.status === 202) {
+      const progress = pollResponse.headers.get('X-Progress')
+      Logger.getLogger().info(`Async $package still processing${progress ? ': ' + progress : ''}`)
+    } else {
+      const errorText = await pollResponse.text()
+      throw new Error(`Async $package poll failed with status ${pollResponse.status}: ${errorText}`)
+    }
+  }
+
+  throw new Error('Async $package operation timed out after maximum poll attempts')
+}
 
 export default PackageQueue


### PR DESCRIPTION
Updates PackageQueue to use the FHIR async request pattern (Prefer: respond-async) when calling $package on CQF, resolving 504 timeouts caused by CQF's ~80s server-side prep phase exceeding the infrastructure's 60s idle connection timeout.

The worker now handles a 202 Accepted response by polling the Content-Location status URL every 10 seconds until the server returns the completed bundle, with a 2-hour maximum.

Falls back gracefully to synchronous handling if the server returns 200 directly, preserving backwards compatibility with environments that don't support async.

Removes the V1 export path from PackageQueue (V1/V2 toggle removed from UI).
Removes debug logging of parameters which exposes VSAC keys