### PR TITLE
Resolve Changelog Issues

### DIFF
--- a/vsm-app/components/DiffViewer/DiffViewerTypes.ts
+++ b/vsm-app/components/DiffViewer/DiffViewerTypes.ts
@@ -313,7 +313,7 @@ interface GrouperVsPage {
       value: string | undefined
       operation?: OldChangeOperation
     }
-    leafValuesets: LeafVsItemOld[]
+    leafValueSets: LeafVsItemOld[]
     codes: FlatCodeOld[]
   }
   newData?: {
@@ -338,7 +338,7 @@ interface GrouperVsPage {
       value: string | undefined
       operation?: NewChangeOperation
     }
-    leafValuesets: LeafVsItemNew[] 
+    leafValueSets: LeafVsItemNew[]
     codes: FlatCodeNew[]
   }
 }

--- a/vsm-app/helpers/createTables.ts
+++ b/vsm-app/helpers/createTables.ts
@@ -240,13 +240,13 @@ const uniqueCodeSystems = (csArray: { name: string, oid: string }[]): { name: st
 // need to always include text on conditions items
 const generateGrouperValueSetTable = (grouperPage: GrouperVsPage) => {
   // doing this here because it's not explicitly noted in the changelog
-  const allOldLeafIds = grouperPage?.oldData?.leafValuesets?.map(oldLeaf => oldLeaf?.memberOid) || []
-  const newLeafIds = grouperPage?.newData?.leafValuesets?.map(newLeaf => newLeaf?.memberOid) || []
+  const allOldLeafIds = grouperPage?.oldData?.leafValueSets?.map(oldLeaf => oldLeaf?.memberOid) || []
+  const newLeafIds = grouperPage?.newData?.leafValueSets?.map(newLeaf => newLeaf?.memberOid) || []
 
   const deletedLeafIds = allOldLeafIds.filter(id => !newLeafIds.includes(id))
-  const deletedValueSets = grouperPage?.oldData?.leafValuesets?.filter(vs => deletedLeafIds?.includes(vs?.memberOid)) || []
+  const deletedValueSets = grouperPage?.oldData?.leafValueSets?.filter(vs => deletedLeafIds?.includes(vs?.memberOid)) || []
 
-  let newData: { change: string; codeSystems: { name: string; oid: string }[]; name: any; oid: any; priority: any; conditionUpdates: ({ conditionChange: string; conditionName: any; conditionCodeSystemVersion: undefined; conditionCode: any; conditionSystem: any } | { conditionChange: undefined; conditionName: undefined; conditionCodeSystemVersion: undefined; conditionSystem: any; conditionCode: any } | undefined)[] }[] = grouperPage?.newData?.leafValuesets?.map(gi => {
+  let newData: { change: string; codeSystems: { name: string; oid: string }[]; name: any; oid: any; priority: any; conditionUpdates: ({ conditionChange: string; conditionName: any; conditionCodeSystemVersion: undefined; conditionCode: any; conditionSystem: any } | { conditionChange: undefined; conditionName: undefined; conditionCodeSystemVersion: undefined; conditionSystem: any; conditionCode: any } | undefined)[] }[] = grouperPage?.newData?.leafValueSets?.map(gi => {
     const newCodeSystems = uniqueCodeSystems(gi?.codeSystems || [])
     return ({
       change: generateMainChangeText(gi),

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -1,6 +1,7 @@
 import ExcelJS from 'exceljs'
 import FhirClient from '@/backend/clients/FhirCdrClient'
 import { getVsSteward, getVsAuthor, getOid } from '@/helpers/valueSetHelpers'
+import { fetchByCanonical } from '@/helpers/server/serverValueSetHelper'
 import { startCase, times, uniq } from 'lodash'
 import { Agent, fetch as f } from 'undici'
 interface CollectedChange extends ChangeValue {
@@ -308,18 +309,22 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
   await Promise.all(
     groupingValueSetsChangeLogs.map(async (page: any) => {
       const currentId = page.newData?.id?.value || page.oldData?.id?.value // use new ID unless it's a deleted grouper
-      const grouperVs = (await FhirClient.getInstance().read({
+      const currentVsVersion = page.newData?.version?.value || page.oldData?.version?.value
+      // page.newData/oldData.id.value is not a real server-assigned resource id - look it up by canonical url/version instead
+      const grouperVsSearch = await fetchByCanonical({
+        client: FhirClient.getInstance(),
         resourceType: 'ValueSet',
-        id: currentId
-      })) as fhir4.ValueSet
+        canonical: currentVsVersion ? `${page.url}|${currentVsVersion}` : page.url
+      })
+      const grouperVs = grouperVsSearch?.entry?.[0]?.resource as fhir4.ValueSet
       const groupingValueSetSheet: ExcelJS.Worksheet = workbook.addWorksheet(grouperVs?.name || grouperVs?.title)
       groupingValueSetSheet.getColumn('A').width = 30
       groupingValueSetSheet.getColumn('B').width = 60
       const vsInfo = [
-        ['Value Set Name', page.title],
+        ['Value Set Name', page.newData?.title?.value],
         ['OID', grouperVs?.identifier?.[0]?.value?.replace('urn:oid:', '')],
         ['Type', 'Grouping'],
-        ['Definition Version', grouperVs.status],
+        ['Definition Version', grouperVs?.status],
         ['Steward', getVsSteward(grouperVs)],
         ['Author', getVsAuthor(grouperVs)],
         ['Publisher', grouperVs.publisher],

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -97,7 +97,7 @@ const autosortTable = (table: ExcelJS.Table, tableRows: ExcelJS.Rows, sheet: Exc
 }
 
 const changeLogDiffOperation = async (sourceId: string, targetId: string, input: fhir4.Parameters) => {
-  const changeJson = await f(`${FhirClient.getInstance().baseUrl}/$create-changelog`, {
+  const changeJson = await f(`${FhirClient.getInstance().baseUrl}/Library/$create-changelog`, {
     body: JSON.stringify(input),
     method: 'POST',
     dispatcher: new Agent({

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -368,8 +368,8 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
           })
         })
       }
-      const oldToMerge = collector(page.oldData?.leafValuesets)
-      const newToMerge = collector(page.newData?.leafValuesets)
+      const oldToMerge = collector(page.oldData?.leafValueSets)
+      const newToMerge = collector(page.newData?.leafValueSets)
       const leafValueSets = mergeChanges(oldToMerge, newToMerge)
       fillGroupingListTableRows(leafValueSets)
 

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -20,7 +20,7 @@ type ChangeValue = {
   display: string
   version: string
   system: string
-  code: string
+  codeValue: string
   memberOid: string
 }
 
@@ -410,7 +410,7 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
       const fillCodeRows = (data: CollectedChangeMap) => {
         Object.entries(data).forEach(([key, value]) => {
           value?.forEach((rowValue) => {
-            const { display: descriptor, memberOid, version, code, codeSystemName, parentValueSetName } = rowValue
+            const { display: descriptor, memberOid, version, codeValue: code, codeSystemName, parentValueSetName } = rowValue
             const status = startCase(grouperVs?.status || '')
             const remapInfo = status === 'Active' ? 'No' : 'Yes'
             codeRows.push([parentValueSetName, memberOid, code, descriptor, codeSystemName, version, status, remapInfo, key])

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -183,23 +183,23 @@ const generateReadMeSheet = (
   const currentVersionHeader = readmeSheet.addRow(['Current Version'])
   currentVersionHeader.font = { bold: true }
   const currentVersion = readmeSheet.addRows([
+    ['Name', targetGrouperLibrary.title],
+    ['Purpose', targetGrouperLibrary?.purpose],
+    ['RCTC OID', getOid(targetGrouperLibrary)],
+    ['RCTC Definition Version', targetGrouperLibrary?.version],
+    ['RCTC Definition Effective Start Date', targetGrouperLibrary?.effectivePeriod?.start],
+    ['RCTC Release Label', targetGrouperLibrary?.version]
+  ])
+  readmeSheet.addRow([]) // Add new line
+  const previousVersionHeader = readmeSheet.addRow(['Previous Version'])
+  previousVersionHeader.font = { bold: true }
+  const previousVersion = readmeSheet.addRows([
     ['Name', sourceGrouperLibrary.title],
     ['Purpose', sourceGrouperLibrary?.purpose],
     ['RCTC OID', getOid(sourceGrouperLibrary)],
     ['RCTC Definition Version', sourceGrouperLibrary?.version],
     ['RCTC Definition Effective Start Date', sourceGrouperLibrary?.effectivePeriod?.start],
     ['RCTC Release Label', sourceGrouperLibrary?.version]
-  ])
-  readmeSheet.addRow([]) // Add new line
-  const previousVersionHeader = readmeSheet.addRow(['Previous Version'])
-  previousVersionHeader.font = { bold: true }
-  const previousVersion = readmeSheet.addRows([
-    ['Name', targetGrouperLibrary.title],
-    ['Purpose', targetGrouperLibrary?.purpose],
-    ['RCTC OID', getOid(sourceGrouperLibrary)],
-    ['RCTC Definition Version', targetGrouperLibrary?.version],
-    ['RCTC Definition Effective Start Date', targetGrouperLibrary?.effectivePeriod?.start],
-    ['RCTC Release Label', targetGrouperLibrary?.version]
   ])
   const cellsToStyle = [currentVersion, previousVersion]
   cellsToStyle.forEach((rows) => {

--- a/vsm-app/pages/api/programs/[id]/compare.ts
+++ b/vsm-app/pages/api/programs/[id]/compare.ts
@@ -40,7 +40,7 @@ const downloadChangeLog = async (req: NextApiRequest, res: NextApiResponse): Pro
   const sourceGrouperLibrary = (await getGrouperLibrary(sourceLibrary)) as fhir4.Library
   const targetGrouperLibrary = (await getGrouperLibrary(targetLibrary)) as fhir4.Library
   const grouperLibDiffJson = changeJson.pages.filter(
-    (page: any) => page.resourceType === 'Library' && page.oldData?.id?.operation?.newValue === targetGrouperLibrary.id
+    (page: any) => page.resourceType === 'Library' && page.url === targetGrouperLibrary.url
   )?.[0]
 
   const groupingValueSetsChangeLogs = changeJson.pages.filter((page: any) => page.resourceType === 'ValueSet')

--- a/vsm-app/pages/programs/compare/index.tsx
+++ b/vsm-app/pages/programs/compare/index.tsx
@@ -292,16 +292,9 @@ const ProgramCompare = () => {
           return json // still in progress
         }
 
-        const diffItemToAdd = {
-          [base.value]: {
-            [target.value]: json
-          }
-        }
-
-        const existingDiffData = rawDiffData || {}
-
-        const updatedDiffData = Object.assign({}, existingDiffData, diffItemToAdd)
-        setRawDiffData(updatedDiffData)
+        // Note: `json` here is the raw Bull Job envelope, not the parsed changelog data
+        // (that only exists once JSON.parse(json.returnvalue) runs in setDiffResults).
+        // Don't write it into rawDiffData - that's reserved for the actual parsed changelog.
         return json
       }
     } catch (e) {
@@ -318,7 +311,12 @@ const ProgramCompare = () => {
     const existingData = rawDiffData?.[baseProgram.value]?.[targetProgram.value]
 
     if (existingData) {
-      // just use existing data if it's there
+      // use existing data if it's there, but still need to build the viewer's
+      // formatted data since it may have been cleared by a dropdown change
+      // @ts-ignore
+      const formattedChangelog = createTableData(existingData)
+      // @ts-ignore
+      setDiffViewerFormattedData(formattedChangelog)
       setIsLoadingDiff(false)
       toast.success('Using existing difference data')
       

--- a/vsm-app/pages/programs/compare/index.tsx
+++ b/vsm-app/pages/programs/compare/index.tsx
@@ -3,7 +3,7 @@ import { useGetPrograms } from '@/hooks/useGetPrograms'
 import { CircularProgress, Drawer, IconButton, Tooltip } from '@mui/material'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { useRouter } from 'next/router'
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import Select from 'react-select'
 import styled from 'styled-components'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
@@ -234,6 +234,11 @@ interface ChangelogItem {
 
 type ChangelogItemMap = Record<string, ChangelogItem>
 
+// Used to guard against two concurrent loadDiffResults calls for the same
+// base/target pair both kicking off a changelog request before either has a job id to
+// de-dupe against.
+const inFlightChangelogs = new Set<string>()
+
 const ProgramCompare = () => {
   const router = useRouter()
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
@@ -246,6 +251,9 @@ const ProgramCompare = () => {
 
   // is it just diff viewer, or also download
   const [downloadLoading, setDownloadLoading] = useState(false)
+
+  // cleanup function for the most recent NotificationStore.listenForJob subscription
+  const listenForJobCleanupRef = useRef<(() => void) | null>(null)
 
   // @ts-ignore
   const allPrograms = useGetPrograms([]) || []
@@ -367,6 +375,13 @@ const ProgramCompare = () => {
 
   const loadDiffResults = async (base: any, target: any) => {
     if (base?.value && target?.value) {
+      const pairKey = `${base.value}:${target.value}`
+      if (inFlightChangelogs.has(pairKey)) {
+        // Already generating/listening for this exact pair
+        return
+      }
+      inFlightChangelogs.add(pairKey)
+
       const diffResponse = await getRawDiffData({ base, target })
       if (diffResponse?.error) {
         toast.error(
@@ -374,12 +389,13 @@ const ProgramCompare = () => {
         )
         setDownloadLoading(false)
         setIsLoadingDiff(false)
+        inFlightChangelogs.delete(pairKey)
         return
       } else if (diffResponse != null && diffResponse.finishedOn == null) {
         // if create-changelog is still in progress...
         toast.info('Difference data is being generated.')
 
-        NotificationStore.listenForJob(diffResponse.id, async (job: JobData) => {
+        listenForJobCleanupRef.current = NotificationStore.listenForJob(diffResponse.id, async (job: JobData) => {
           if (job?.status === JOB_STATUS.COMPLETED) {
             toast.success('Difference generated successfully')
             const diffResponse = await getRawDiffData({ base, target }) // get the data again
@@ -392,11 +408,13 @@ const ProgramCompare = () => {
             setIsLoadingDiff(false)
             setIsError(true)
           }
+          inFlightChangelogs.delete(pairKey)
         })
         return
       }
 
       setDiffResults(base, target, diffResponse)
+      inFlightChangelogs.delete(pairKey)
     }
   }
 
@@ -432,6 +450,10 @@ const ProgramCompare = () => {
       setBaseProgram(base!)
       setTargetProgram(target!)
       loadDiffResults(base, target)
+    }
+    return () => {
+      listenForJobCleanupRef.current?.()
+      listenForJobCleanupRef.current = null
     }
   }, [formattedProgramOptions])
 

--- a/vsm-app/store/NotificationStore.ts
+++ b/vsm-app/store/NotificationStore.ts
@@ -21,6 +21,11 @@ let state = {} as Jobs
 
 let uiListener: Subject<any> | null = null
 
+// Tracks jobIds that already have an active uiListener subscription, so repeated
+// listenForJob calls for the same job don't stack up duplicate subscriptions that each fire their
+// own toast for the same completion event.
+const activeListenerJobIds = new Set<string>()
+
 const notifyUiListener = (nextState: Jobs) => {
   subject.next(nextState)
   if (uiListener !== null) {
@@ -45,6 +50,12 @@ const NotificationStore = {
   listenForJob: (targetedJobId: string, callback: Function) => {
     console.log(`[NotificationStore] listenForJob called for jobId: ${targetedJobId}`)
 
+    if (activeListenerJobIds.has(targetedJobId)) {
+      console.log(`[NotificationStore] Listener already active for job: ${targetedJobId}, skipping duplicate`)
+      return () => {}
+    }
+    activeListenerJobIds.add(targetedJobId)
+
     // Create a new listener if it doesn't exist
     if (!uiListener) {
       console.log('[NotificationStore] Creating new uiListener Subject')
@@ -66,6 +77,7 @@ const NotificationStore = {
     return () => {
       console.log(`[NotificationStore] Cleaning up listener for job: ${targetedJobId}`)
       subscription.unsubscribe()
+      activeListenerJobIds.delete(targetedJobId)
     }
   },
   addJob: async ({ jobId, jobType, metadata, onSuccess, onFailure, updateStatus }: AddJobParams) => {

--- a/vsm-app/utils/subscribe.ts
+++ b/vsm-app/utils/subscribe.ts
@@ -16,8 +16,17 @@ type SubscribeProps = {
   onFailure?: any
 }
 
+// Tracks jobIds that already have an active polling loop, so repeated subscribe() calls
+// for the same job don't spin up duplicate pollers that each independently
+// fire their own completion/failure toast.
+const activePollingJobIds = new Set<string>()
+
 const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {}, onFailure = () => {} }: SubscribeProps) => {
-  if (!jobIds.length) return
+  const idsToSubscribe = jobIds.filter((jobId) => !activePollingJobIds.has(jobId))
+  if (!idsToSubscribe.length) return
+  idsToSubscribe.forEach((jobId) => activePollingJobIds.add(jobId))
+  const stopTracking = () => idsToSubscribe.forEach((jobId) => activePollingJobIds.delete(jobId))
+
   // Create an observable for polling
   const polling$ = timer(0, 5000).pipe(
     switchMap(() =>
@@ -26,7 +35,7 @@ const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(jobIds)
+        body: JSON.stringify(idsToSubscribe)
       })
         .then(async (response) => {
           const res = await response.json()
@@ -46,6 +55,7 @@ const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {
     catchError((error) => {
       console.error('Something went wrong', error)
       onFailure(error)
+      stopTracking()
       return of(null) // Complete the observable if there's an error
     })
   )
@@ -57,7 +67,7 @@ const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {
       return false
     } else if (status === JOB_STATUS.COMPLETED) {
       onSuccess()
-      NotificationStore.completedJobs(jobIds) // completedJobs takes an array of ids
+      NotificationStore.completedJobs(idsToSubscribe) // completedJobs takes an array of ids
       return false
     } else {
       // Job is still in progress exit out
@@ -78,6 +88,7 @@ const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {
       const shouldContinue = pollingDecision(jobId, jobDetails?.status, jobDetails?.error! || '')
       if (!shouldContinue) {
         subscription.unsubscribe() // Stop polling
+        stopTracking()
       }
     } else if (currentJobIds.length > 1) {
       // Handle case of polling multiple jobs
@@ -107,6 +118,7 @@ const subscribe = ({ jobIds, onSuccess = defaultOnSuccess, setMetaData = () => {
         toast.success('Job failed')
       }
       subscription.unsubscribe() // Stop polling
+      stopTracking()
       if (completedJobs.length + failedJobs.length !== currentJobIds.length) {
         NotificationStore.resubscribeJobs() // Resubscribe to all in progress jobs
       }


### PR DESCRIPTION
Fix issues with $create-changelog:

- Point operation at correct endpoint (add /Library/)
- Fix typo preventing ValueSet changes from rendering
- Fix response formatting and ensure diff viewer stays in sync with generated diff
- Fix grouper retrieval (retrieve by canonical instead of ID) and update 'ValueSetName' cell value to align with data structure
- Fix issue where Grouper Library diff wasn't resolved unless it's ID had changed (now matches on URL)
- Fix issue where spreadsheet currentVersion pointed to sourceLibrary and vice versa
- Fix issue where spreadsheet CodeList code cells weren't populated (bind codeValue to code)
- Add logic to prevent duplication of Job related toast notifications