### PR TITLE
Fix ValueSet rows merging data across versioned/unversioned duplicates

### DIFF
--- a/vsm-app/components/ProgramValueSetDetails/index.tsx
+++ b/vsm-app/components/ProgramValueSetDetails/index.tsx
@@ -77,6 +77,8 @@ export interface HandleVersionChange {
   selectedVsId: string
   selectedVersion: string
   vsCanonical: string
+  // lets the server retarget only the depends-on entry for this specific grouper membership
+  previousPinnedCanonical: string
   grouperIds: string[]
   terminologyInfo: TerminologyResult
 }
@@ -204,7 +206,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
         body
       }).then((res) => res.json())
 
-      const oldConditions = conditionsMap[vsUrl]
+      const oldConditions = conditionsMap[row?.pinnedCanonical ?? vsUrl]
       const conditionAction = oldConditions?.length > conditions?.length ? 'removed' : `added ${conditions?.[conditions.length - 1]?.label}`
       toast.success(`Successfully ${conditionAction} condition`)
       setCurrentProgram(updatedLibrary)
@@ -324,6 +326,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
       selectedVersion: e?.value as string,
       useContext: row?.valueSet?.useContext || [],
       vsCanonical: row?.valueSet?.url as string,
+      previousPinnedCanonical: row?.pinnedCanonical ?? (row?.valueSet?.url as string),
       programId: currentProgram?.id as string,
       grouperIds,
       terminologyInfo
@@ -454,7 +457,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
         allowOverflow: true,
         wrap: true,
         cell: (row: TableRow, index: number) => {
-          const priorityKey = row?.valueSet?.url ?? ''
+          const priorityKey = row?.pinnedCanonical ?? row?.valueSet?.url ?? ''
           const currentPriority = valueSetPriorityMap[priorityKey] as string
           const currentPriorityValue = currentPriority
             ? priorityLevelOptions.find((i) => i.id === currentPriority)
@@ -613,7 +616,7 @@ const ProgramValueSetDetails = ({ router, program }: ProgramValueSetDetailsProps
         wrap: true,
         minWidth: '210px',
         cell: (row: TableRow, index: number) => {
-          const vsConditions = conditionsMap[row?.valueSet?.url!] || []
+          const vsConditions = conditionsMap[row?.pinnedCanonical ?? row?.valueSet?.url!] || []
           const selectedOptions = vsConditions
             ?.map((i) => {
               const system = i?.valueCodeableConcept?.coding?.[0]?.system

--- a/vsm-app/helpers/libraryHelpers.spec.ts
+++ b/vsm-app/helpers/libraryHelpers.spec.ts
@@ -273,6 +273,21 @@ describe('libraryHelpers', () => {
         expect(map[`${bareUrl}|1234`]).toBe('emergent')
         expect(map[bareUrl]).toBe('routine')
       })
+
+      it('should not let a pinned entrys bare url fallback clobber the unpinned entrys own value, regardless of processing order', () => {
+        const bareUrl = 'http://cts.nlm.nih.gov/fhir/ValueSet/33333'
+        // same fixture as above, but with the unpinned entry listed FIRST - the bare-url
+        // lookup must resolve the same way either way
+        testProgram.relatedArtifact = [
+          buildPriorityRelatedArtifact(bareUrl, 'routine'),
+          buildPriorityRelatedArtifact(`${bareUrl}|1234`, 'emergent')
+        ]
+
+        const map = getVSPriority(testProgram)
+
+        expect(map[`${bareUrl}|1234`]).toBe('emergent')
+        expect(map[bareUrl]).toBe('routine')
+      })
     })
 
     describe('setVSPriority', () => {

--- a/vsm-app/helpers/libraryHelpers.spec.ts
+++ b/vsm-app/helpers/libraryHelpers.spec.ts
@@ -12,7 +12,8 @@ import {
   getVSConditions,
   addVSConditions,
   updateGrouperLeafs,
-  deleteLeafsFromLibrary
+  deleteLeafsFromLibrary,
+  USHealthVSPriority
 } from './libraryHelpers'
 import { Condition } from './conditionHelpers'
 
@@ -232,6 +233,45 @@ describe('libraryHelpers', () => {
         const map = getVSPriority(testProgram)
         expect(map['http://cts.nlm.nih.gov/fhir/ValueSet/33333']).toBe('emergent')
         expect(map['http://cts.nlm.nih.gov/fhir/ValueSet/33333||1234']).toBeUndefined()
+      })
+
+      const buildPriorityRelatedArtifact = (resource: string, code: USHealthVSPriority): fhir4.RelatedArtifact => ({
+        type: 'depends-on',
+        resource,
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-intendedUsageContext',
+            valueUsageContext: {
+              code: {
+                system: 'http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type',
+                code: 'priority'
+              },
+              valueCodeableConcept: {
+                coding: [
+                  {
+                    system: 'http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context',
+                    code
+                  }
+                ],
+                text: code
+              }
+            }
+          }
+        ]
+      })
+
+      it('should keep a pinned and unpinned entry for the same bare url independent, while still exposing a bare url lookup', () => {
+        const bareUrl = 'http://cts.nlm.nih.gov/fhir/ValueSet/33333'
+        testProgram.relatedArtifact = [
+          buildPriorityRelatedArtifact(`${bareUrl}|1234`, 'emergent'),
+          buildPriorityRelatedArtifact(bareUrl, 'routine')
+        ]
+
+        const map = getVSPriority(testProgram)
+
+        // each pinned/unpinned entry resolves to its own priority via its exact canonical
+        expect(map[`${bareUrl}|1234`]).toBe('emergent')
+        expect(map[bareUrl]).toBe('routine')
       })
     })
 
@@ -469,6 +509,50 @@ describe('libraryHelpers', () => {
       })
       it('Returns an empty object if there are no conditions in a program', () => {
         expect(getVSConditions(FIXTURE_PROGRAM_1)).toStrictEqual({})
+      })
+
+      const buildConditionRelatedArtifact = (resource: string, code: string, text: string): fhir4.RelatedArtifact => ({
+        type: 'depends-on',
+        resource,
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-intendedUsageContext',
+            valueUsageContext: {
+              code: {
+                system: 'http://hl7.org/fhir/us/ecr/CodeSystem/us-ph-usage-context-type',
+                code: 'focus'
+              },
+              valueCodeableConcept: {
+                coding: [{ system: 'http://snomed.info/sct', code }],
+                text
+              }
+            }
+          }
+        ]
+      })
+
+      it('keeps a pinned and unpinned entry for the same bare url independent, and aggregates them under a bare url lookup', () => {
+        const bareUrl = 'http://cts.nlm.nih.gov/fhir/ValueSet/99999'
+        const program = cloneDeep(FIXTURE_PROGRAM_1)
+        program.relatedArtifact = [
+          buildConditionRelatedArtifact(`${bareUrl}|1.0`, '111', 'Condition A'),
+          buildConditionRelatedArtifact(bareUrl, '222', 'Condition B')
+        ]
+
+        const map = getVSConditions(program)
+
+        // the pinned entry's exact canonical only sees its own condition
+        expect(map[`${bareUrl}|1.0`]).toStrictEqual([
+          { id: 'http://snomed.info/sct|111', valueCodeableConcept: { coding: [{ system: 'http://snomed.info/sct', code: '111' }], text: 'Condition A' } }
+        ])
+        // the unpinned entry's exact canonical (the bare url itself) sees only its own condition too
+        // BUT since it collides with the bare url aggregate key, it ends up merged with the pinned
+        // entry's condition there. this is the tradeoff for keeping a bare url lookup
+        // available for callers (e.g. code search) that can't distinguish by pinned version
+        expect(map[bareUrl]).toStrictEqual([
+          { id: 'http://snomed.info/sct|111', valueCodeableConcept: { coding: [{ system: 'http://snomed.info/sct', code: '111' }], text: 'Condition A' } },
+          { id: 'http://snomed.info/sct|222', valueCodeableConcept: { coding: [{ system: 'http://snomed.info/sct', code: '222' }], text: 'Condition B' } }
+        ])
       })
     })
     describe('addVsConditions', () => {
@@ -947,6 +1031,25 @@ const FIXTURE_PROGRAM_CONDITIONS_1 = {
 } as fhir4.Library
 
 const FIXTURE_PROGRAM_CONDITIONS_1_RESULT =     {
+  // pinned canonical key: what ProgramValueSetDetails uses to distinguish rows that
+  // share a bare url but were pinned to different versions
+  'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6|20210526': [
+    {
+      id: 'http://snomed.info/sct|49649001',
+      valueCodeableConcept: {
+        coding: [ { system: 'http://snomed.info/sct', code: '49649001' } ],
+        text: 'Infection caused by Acanthamoeba (disorder)'
+      }
+    },
+    {
+      id: 'http://snomed.info/sct|767146004',
+      valueCodeableConcept: {
+        coding: [ { system: 'http://snomed.info/sct', code: '767146004' } ],
+        text: 'Toxic effect of arsenic and/or arsenic compound'
+      }
+    }
+  ],
+  // bare url key: kept for callers (e.g. code search) that can't distinguish by version
   'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.6': [
     {
       id: 'http://snomed.info/sct|49649001',

--- a/vsm-app/helpers/libraryHelpers.ts
+++ b/vsm-app/helpers/libraryHelpers.ts
@@ -249,8 +249,9 @@ const getVSPriority = (library: fhir4.Library) => {
 
     if (!priorityExt) return
 
-    // extract values safely
-    const vsUrl = ra.resource?.split('|')?.[0] as string | undefined
+    // extract values safely - keep the full pinned canonical so a
+    // versioned and unversioned depends-on entry for the same url don't collide
+    const vsUrl = ra.resource
     const priorityCode = (priorityExt as any)?.valueUsageContext?.valueCodeableConcept?.coding?.[0]?.code as
       | string
       | undefined
@@ -263,6 +264,12 @@ const getVSPriority = (library: fhir4.Library) => {
     }
 
     vsPriorityMap[vsUrl] = priorityCode as USHealthVSPriority
+
+    // also keep a bare url entry for callers that can't identify by pinned version
+    const [bareUrl] = vsUrl.split('|')
+    if (bareUrl !== vsUrl) {
+      vsPriorityMap[bareUrl] = priorityCode as USHealthVSPriority
+    }
   })
 
   return vsPriorityMap
@@ -292,7 +299,9 @@ const getVSConditions = (program: fhir4.Library) => {
     )
 
     if (artifact?.type === 'depends-on' && conditionExtensions?.length) {
-      const vsUrl = artifact.resource?.split('|')?.[0] as string
+      // keep the full pinned canonical so a versioned and unversioned
+      // depends-on entry for the same url dont collide
+      const vsUrl = artifact.resource as string
 
       const arrangedConditions = conditionExtensions
         .map((ext) => {
@@ -319,6 +328,16 @@ const getVSConditions = (program: fhir4.Library) => {
           vsConditions[vsUrl] = arrangedConditions
         } else {
           vsConditions[vsUrl] = vsConditions[vsUrl].concat(arrangedConditions)
+        }
+
+        // also keep a bare url entry for callers that can't identify by pinned version
+        const [bareUrl] = vsUrl.split('|')
+        if (bareUrl !== vsUrl) {
+          if (!vsConditions[bareUrl]) {
+            vsConditions[bareUrl] = arrangedConditions
+          } else {
+            vsConditions[bareUrl] = vsConditions[bareUrl].concat(arrangedConditions)
+          }
         }
       }
     }

--- a/vsm-app/helpers/libraryHelpers.ts
+++ b/vsm-app/helpers/libraryHelpers.ts
@@ -235,6 +235,9 @@ const setVSPriority = (target: fhir4.Library, code: USHealthVSPriority, canonica
 
 const getVSPriority = (library: fhir4.Library) => {
   const vsPriorityMap: Record<string, USHealthVSPriority> = {}
+  // bare urls that have their own depends-on entry (i.e. keyed by the bare url itself, not
+  // a pinned sibling). The fallback below must never overwrite its value,regardless of which entry is processed first
+  const bareUrlsWithOwnPriorityEntry = new Set<string>()
 
   library?.relatedArtifact?.forEach((ra) => {
     if (ra?.type !== 'depends-on' || !ra?.extension?.length) return
@@ -265,9 +268,13 @@ const getVSPriority = (library: fhir4.Library) => {
 
     vsPriorityMap[vsUrl] = priorityCode as USHealthVSPriority
 
-    // also keep a bare url entry for callers that can't identify by pinned version
     const [bareUrl] = vsUrl.split('|')
-    if (bareUrl !== vsUrl) {
+    if (bareUrl === vsUrl) {
+      bareUrlsWithOwnPriorityEntry.add(bareUrl)
+    } else if (!bareUrlsWithOwnPriorityEntry.has(bareUrl)) {
+      // bare url fallback for callers that can't identify by pinned version - skipped once
+      // this bare url has its own entry, so that value can't be overwritten no matter which
+      // order relatedArtifact entries are processed in
       vsPriorityMap[bareUrl] = priorityCode as USHealthVSPriority
     }
   })

--- a/vsm-app/helpers/server/serverValueSetHelper.spec.ts
+++ b/vsm-app/helpers/server/serverValueSetHelper.spec.ts
@@ -1,0 +1,81 @@
+import FhirClient from '@/backend/clients/FhirCdrClient'
+import { fetchLeafValueSets, ValueSetWithPin } from './serverValueSetHelper'
+
+jest.mock('fhir-kit-client')
+
+describe('serverValueSetHelper', () => {
+  describe('fetchLeafValueSets', () => {
+    it('tags a resolved ValueSet with the canonical (bare or pinned) used to look it up', async () => {
+      FhirClient.getInstance().batch = jest.fn().mockResolvedValueOnce({
+        entry: [
+          {
+            resource: {
+              entry: [
+                { resource: { resourceType: 'ValueSet', id: 'foo-latest', url: 'http://example.com/ValueSet/foo', version: '2.0' } }
+              ]
+            }
+          }
+        ]
+      })
+
+      const result = await fetchLeafValueSets({ leafValueSetCanonicals: ['http://example.com/ValueSet/foo'] })
+
+      expect(result?.[0]?.pinnedCanonical).toBe('http://example.com/ValueSet/foo')
+    })
+
+    it('keeps the pinned and unpinned canonical correctly paired to their own resolved ValueSet, not swapped', async () => {
+      // one batch entry per requested canonical, in request order - simulates the FHIR
+      // server resolving a pinned request and an unpinned request for the same bare url
+      // to two different underlying resources
+      FhirClient.getInstance().batch = jest.fn().mockResolvedValueOnce({
+        entry: [
+          {
+            resource: {
+              entry: [
+                { resource: { resourceType: 'ValueSet', id: 'foo-1.0', url: 'http://example.com/ValueSet/foo', version: '1.0' } }
+              ]
+            }
+          },
+          {
+            resource: {
+              entry: [
+                { resource: { resourceType: 'ValueSet', id: 'foo-latest', url: 'http://example.com/ValueSet/foo', version: '2.0' } }
+              ]
+            }
+          }
+        ]
+      })
+
+      const result = await fetchLeafValueSets({
+        leafValueSetCanonicals: ['http://example.com/ValueSet/foo|1.0', 'http://example.com/ValueSet/foo']
+      })
+
+      const pinnedRow = result?.find((vs: ValueSetWithPin) => vs.id === 'foo-1.0')
+      const unpinnedRow = result?.find((vs: ValueSetWithPin) => vs.id === 'foo-latest')
+
+      expect(pinnedRow?.pinnedCanonical).toBe('http://example.com/ValueSet/foo|1.0')
+      expect(unpinnedRow?.pinnedCanonical).toBe('http://example.com/ValueSet/foo')
+    })
+
+    it('tags the chosen "latest" resource when a single query resolves to more than one match', async () => {
+      FhirClient.getInstance().batch = jest.fn().mockResolvedValueOnce({
+        entry: [
+          {
+            resource: {
+              entry: [
+                { resource: { resourceType: 'ValueSet', id: 'foo-old', url: 'http://example.com/ValueSet/foo', version: '2020-01-01' } },
+                { resource: { resourceType: 'ValueSet', id: 'foo-new', url: 'http://example.com/ValueSet/foo', version: '2024-01-01' } }
+              ]
+            }
+          }
+        ]
+      })
+
+      const result = await fetchLeafValueSets({ leafValueSetCanonicals: ['http://example.com/ValueSet/foo'] })
+
+      expect(result).toHaveLength(1)
+      expect(result?.[0]?.id).toBe('foo-new')
+      expect(result?.[0]?.pinnedCanonical).toBe('http://example.com/ValueSet/foo')
+    })
+  })
+})

--- a/vsm-app/helpers/server/serverValueSetHelper.ts
+++ b/vsm-app/helpers/server/serverValueSetHelper.ts
@@ -3,6 +3,12 @@ import FhirKitClient, { ResourceType } from 'fhir-kit-client'
 import { is } from '@/helpers/is'
 import dayjs from 'dayjs'
 import Logger from './logger'
+
+// a ValueSet resolved via fetchLeafValueSets, tagged with the (possibly version-pinned)
+// canonical string that was used to look it up - lets callers tell apart two rows for the
+// same ValueSet.url that were pinned to different versions
+export type ValueSetWithPin = fhir4.ValueSet & { pinnedCanonical?: string }
+
 interface FetchGrouperLib {
   client: FhirKitClient
   canonical: string
@@ -199,9 +205,12 @@ export const fetchLeafValueSets = async ({
   try {
     let valueSets
     valueSets = batchResults.entry
-      ?.map((e: any) => {
+      ?.map((e: any, i: number) => {
         const vsBundleEntry = e?.resource?.entry
+        // the canonical (possibly pinned to a version) that produced this entry.
+        const pinnedCanonical = leafValueSetCanonicals[i]
         if (vsBundleEntry) {
+          let resource
           if (vsBundleEntry?.length > 1) {
             // Find latest valueset version to return
             const latestEntry = vsBundleEntry.reduce((acc: fhir4.BundleEntry, cur: fhir4.BundleEntry) => {
@@ -209,12 +218,14 @@ export const fetchLeafValueSets = async ({
               const accDate = new Date((acc.resource as fhir4.ValueSet)?.version || 0)
               return dayjs(curDate).isAfter(accDate) ? cur : acc
             }, vsBundleEntry?.[0])
-            return [latestEntry.resource]
+            resource = latestEntry.resource
           } else if (vsBundleEntry?.length === 1) {
-            return [vsBundleEntry?.[0]?.resource]
+            resource = vsBundleEntry?.[0]?.resource
           } else {
             return
           }
+          if (!resource) return
+          return [{ ...resource, pinnedCanonical: pinnedCanonical } as ValueSetWithPin]
         }
       })
       ?.filter((x: any) => !!x) // filter out undefined

--- a/vsm-app/helpers/valueSetHelpers.spec.ts
+++ b/vsm-app/helpers/valueSetHelpers.spec.ts
@@ -16,7 +16,9 @@ import {
   findUnversionedManifestRefs,
   filterToUnversioned,
   applyVersionUpdate,
-  applyAddManifestEntry
+  applyAddManifestEntry,
+  countDistinctPinsForCanonical,
+  isDependsOnEntryForLeaf
 } from './valueSetHelpers'
 import { uniq } from 'lodash'
 import { DeleteData, UpdateData } from '@/pages/api/codesystem/provisional';
@@ -439,6 +441,96 @@ describe('valueSetHelpers', () => {
     it('Should remove the version if latest version is specified', () => {
       const newValueSet = updateLeafVsVersion(testValueSet1, 'www.example.com/hello', 'latest')
       expect(newValueSet).toMatchObject(testValueSetUpdatedLatest)
+    })
+  })
+
+  describe('countDistinctPinsForCanonical', () => {
+    const bareUrl = 'http://example.com/ValueSet/foo'
+
+    it('returns 1 when only one grouper membership pins this canonical', () => {
+      const groupers = [
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] } }
+      ] as fhir4.ValueSet[]
+
+      expect(countDistinctPinsForCanonical(groupers, bareUrl)).toBe(1)
+    })
+
+    it('returns 2 when a pinned and an unpinned grouper membership both reference this canonical', () => {
+      const groupers = [
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] } },
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [bareUrl] }] } }
+      ] as fhir4.ValueSet[]
+
+      expect(countDistinctPinsForCanonical(groupers, bareUrl)).toBe(2)
+    })
+
+    it('dedupes when the same pin appears in more than one grouper', () => {
+      const groupers = [
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] } },
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] } }
+      ] as fhir4.ValueSet[]
+
+      expect(countDistinctPinsForCanonical(groupers, bareUrl)).toBe(1)
+    })
+
+    it('ignores groupers that reference a different canonical entirely', () => {
+      const groupers = [
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] } },
+        { resourceType: 'ValueSet', compose: { include: [{ valueSet: ['http://example.com/ValueSet/unrelated'] }] } }
+      ] as fhir4.ValueSet[]
+
+      expect(countDistinctPinsForCanonical(groupers, bareUrl)).toBe(1)
+    })
+  })
+
+  describe('isDependsOnEntryForLeaf', () => {
+    const bareUrl = 'http://example.com/ValueSet/foo'
+
+    it('retargets on an exact pin match, regardless of ambiguity', () => {
+      expect(
+        isDependsOnEntryForLeaf({
+          entryResource: `${bareUrl}|1.0`,
+          previousPinnedCanonical: `${bareUrl}|1.0`,
+          vsCanonical: bareUrl,
+          isAmbiguous: true
+        })
+      ).toBe(true)
+    })
+
+    it('falls back to a bare url match when unambiguous, even if the pin does not match', () => {
+      // simulates a fresh eRSD import: the depends-on entry's resource doesn't match the
+      // grouper's own (unpinned) compose.include pin
+      expect(
+        isDependsOnEntryForLeaf({
+          entryResource: `${bareUrl}|some-import-time-version`,
+          previousPinnedCanonical: bareUrl,
+          vsCanonical: bareUrl,
+          isAmbiguous: false
+        })
+      ).toBe(true)
+    })
+
+    it('does not fall back to a bare url match when ambiguous', () => {
+      // this is the case that used to steal a sibling grouper membership's depends-on entry
+      expect(
+        isDependsOnEntryForLeaf({
+          entryResource: `${bareUrl}|2.0`,
+          previousPinnedCanonical: bareUrl,
+          vsCanonical: bareUrl,
+          isAmbiguous: true
+        })
+      ).toBe(false)
+    })
+
+    it('does not match an entry for a completely different canonical', () => {
+      expect(
+        isDependsOnEntryForLeaf({
+          entryResource: 'http://example.com/ValueSet/unrelated',
+          previousPinnedCanonical: bareUrl,
+          vsCanonical: bareUrl,
+          isAmbiguous: false
+        })
+      ).toBe(false)
     })
   })
 

--- a/vsm-app/helpers/valueSetHelpers.ts
+++ b/vsm-app/helpers/valueSetHelpers.ts
@@ -798,6 +798,33 @@ const getLeafUrlsFromGrouper = (grouperVs: fhir4.ValueSet) =>
     ?.filter((x) => !!x) // filter out undefined
     ?.flat() || []
 
+// how many distinct pins (across every grouper in the program) currently point at this bare canonical.
+// >1 means multiple grouper memberships share the same bare url, so it's unsafe to resolve a
+// depends-on entry for one of them by bare url alone
+const countDistinctPinsForCanonical = (grouperValueSets: fhir4.ValueSet[], vsCanonical: string): number => {
+  const allLeafPins = uniq(grouperValueSets.flatMap((vs) => getLeafUrlsFromGrouper(vs)))
+  return allLeafPins.filter((pin) => pin?.split('|')?.[0] === vsCanonical).length
+}
+
+// whether a depends-on relatedArtifact entry belongs to the leaf/pin currently being updated,
+// and so should have its resource updated to the leaf's new pin.
+const isDependsOnEntryForLeaf = ({
+  entryResource,
+  previousPinnedCanonical,
+  vsCanonical,
+  isAmbiguous
+}: {
+  entryResource: string | undefined
+  previousPinnedCanonical: string
+  vsCanonical: string
+  isAmbiguous: boolean
+}): boolean => {
+  const matchesPinnedCanonical = entryResource === previousPinnedCanonical
+  //only safe when this canonical isn't ambiguous
+  const matchesBareCanonical = !isAmbiguous && entryResource?.split('|')?.[0] === vsCanonical
+  return matchesPinnedCanonical || matchesBareCanonical
+}
+
 export {
   organizeValueSetDefinitionData,
   getVsSteward,
@@ -810,6 +837,8 @@ export {
   getProgramManifestVersions,
   getTerminologySource,
   getLeafUrlsFromGrouper,
+  countDistinctPinsForCanonical,
+  isDependsOnEntryForLeaf,
   removeValueSetFromGrouper,
   setExpansionParameters,
   getKeywords,

--- a/vsm-app/hooks/useGetProgramValueSetDetails.ts
+++ b/vsm-app/hooks/useGetProgramValueSetDetails.ts
@@ -33,6 +33,7 @@ export interface DataItem {
   version: string
   valueSet: fhir4.ValueSet
   valueSetPinnedVersion: string | undefined
+  pinnedCanonical?: string
   programStatus: fhir4.Library['status']
 }
 
@@ -123,7 +124,7 @@ const useGetProgramValueSetDetails = ({
       if (!vs.valueSet.url) {
         return false
       }
-      const currentPriority = valueSetPriorityMap[vs.valueSet.url]
+      const currentPriority = valueSetPriorityMap[vs.pinnedCanonical ?? vs.valueSet.url]
       return activePriority?.includes('routine') && currentPriority !== 'emergent' ? true : activePriority?.includes(currentPriority)
     })
     resultData.data = filteredData
@@ -135,7 +136,7 @@ const useGetProgramValueSetDetails = ({
       if (!vs.valueSet.url) {
         return false
       }
-      const currentConditions = conditionsMap[vs.valueSet.url]?.map((i) => i?.id)
+      const currentConditions = conditionsMap[vs.pinnedCanonical ?? vs.valueSet.url]?.map((i) => i?.id)
       // Test for intersection of either array
       return currentConditions?.filter((value) => activeConditionsMap.includes(value)).length > 0
     })

--- a/vsm-app/pages/api/programs/[id]/details/valuesets/index.ts
+++ b/vsm-app/pages/api/programs/[id]/details/valuesets/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import handler from '@/helpers/server/handler'
 import { Result } from '@/hooks/useGetProgramValueSetDetails'
-import { fetchLeafValueSets } from '@/helpers/server/serverValueSetHelper'
+import { fetchLeafValueSets, ValueSetWithPin } from '@/helpers/server/serverValueSetHelper'
 import Logger from '@/helpers/server/logger'
 import { getProgram, getGrouperLibrary, getGrouperValuesets } from '@/helpers/server/serverLibraryHelper'
 import { getLeafUrlsFromGrouper } from '@/helpers/valueSetHelpers'
@@ -45,8 +45,9 @@ const arrangeGroupInfoByValueSetCanonical = (allGrouperVSets: fhir4.ValueSet[]) 
 
     leafUrlsInGrouper?.forEach((leafUrl) => {
       if (!leafUrl) return
-      // arrange by unversioned grouper url
-      const [urlNoVersion, version] = leafUrl.split('|')
+      // arrange by the leaf's pinned canonical (url, or url|version when pinned) so a versioned
+      // and unversioned entry for the same url don't collide on grouper membership
+      const [, version] = leafUrl.split('|')
 
       const groupToAdd = {
         id: grouperVs?.id || 'Undefined',
@@ -55,10 +56,10 @@ const arrangeGroupInfoByValueSetCanonical = (allGrouperVSets: fhir4.ValueSet[]) 
         title: grouperVs.title || ''
       }
 
-      if (groupsByValueSetCanonical[urlNoVersion]) {
-        groupsByValueSetCanonical[urlNoVersion].push(groupToAdd)
+      if (groupsByValueSetCanonical[leafUrl]) {
+        groupsByValueSetCanonical[leafUrl].push(groupToAdd)
       } else {
-        groupsByValueSetCanonical[urlNoVersion] = [groupToAdd]
+        groupsByValueSetCanonical[leafUrl] = [groupToAdd]
       }
     })
   })
@@ -86,13 +87,14 @@ const vsInRequiredGroup = ({ groupsVsBelongsTo, groupIdsToFilterBy }: VsInReqGrp
 const formatValuesetData = (
   program: fhir4.Library,
   groupsByValueSetCanonical: GroupsByCanonical,
-  leafValueSets: fhir4.ValueSet[],
+  leafValueSets: ValueSetWithPin[],
   leafVersionsByCanonical: LeafVersionsByUrl
 ) => {
   const formattedVsets = leafValueSets
     .filter((x) => !!x)
     .map((valueSet, index) => {
-      const leafCanonical = valueSet.url!
+      // fall back to the bare url for callers that don't go through fetchLeafValueSets
+      const leafCanonical = valueSet.pinnedCanonical ?? valueSet.url!
       const groupsVsBelongsTo = groupsByValueSetCanonical[leafCanonical]
       const valueSetPinnedVersion = leafVersionsByCanonical[leafCanonical]
 
@@ -107,6 +109,7 @@ const formatValuesetData = (
         publisher: valueSet?.publisher || '[Undefined]',
         version: valueSet?.version || '[Undefined]',
         valueSetPinnedVersion,
+        pinnedCanonical: leafCanonical,
         valueSet: valueSet,
         groups: groupsVsBelongsTo
       }
@@ -167,14 +170,16 @@ export const getProgramDetailsValuesets = async ({
       titleToFind: findInVsTitle || '',
       whitelistFields: WHITELIST_VALUESET_FIELDS,
       provisionalOnly: false
-    })) as fhir4.ValueSet[]
+    })) as ValueSetWithPin[]
 
     const leafVersionsByCanonical = leafValueSetCanonicals
       ?.filter((canonical) => canonical?.includes('|'))
       ?.reduce((acc, can) => {
-        let [baseCanonical, version] = can.split('|')
-        return { ...acc, [baseCanonical]: version }
-      }, {})
+        // keyed by the full pinned canonical (url|version), not the bare url, so a versioned
+        // and unversioned entry for the same url each resolve to their own pinned version
+        const [, version] = can.split('|')
+        return { ...acc, [can]: version }
+      }, {} as LeafVersionsByUrl)
 
     const groupInfoByVsCanonical = arrangeGroupInfoByValueSetCanonical(grouperValueSets)
 
@@ -188,7 +193,7 @@ export const getProgramDetailsValuesets = async ({
           !!vs &&
           // vs canonical has version on it?
           vsInRequiredGroup({
-            groupsVsBelongsTo: groupInfoByVsCanonical[vs.url!],
+            groupsVsBelongsTo: groupInfoByVsCanonical[vs.pinnedCanonical ?? vs.url!],
             groupIdsToFilterBy: filterGroups
           })
       )

--- a/vsm-app/pages/api/valueset/versions.ts
+++ b/vsm-app/pages/api/valueset/versions.ts
@@ -1,4 +1,4 @@
-import { addExtensionToVs, addProfileToValueSet, EXTENSIONS, transformFromVSACToCqf, updateLeafVsVersion } from '@/helpers/valueSetHelpers'
+import { addExtensionToVs, addProfileToValueSet, countDistinctPinsForCanonical, EXTENSIONS, isDependsOnEntryForLeaf, transformFromVSACToCqf, updateLeafVsVersion } from '@/helpers/valueSetHelpers'
 import TerminologyFhirClient from '@/backend/clients/TerminologyFhirClient'
 import FhirClient from '@/backend/clients/FhirCdrClient'
 import type { NextApiRequest, NextApiResponse } from 'next'
@@ -13,6 +13,7 @@ import { getServerSession } from 'next-auth'
 import { tsCredentialService } from '@/backend/services/TsCredentialService'
 import { AuthOptions } from '../auth/[...nextauth]'
 import { TerminologyServerCredentials } from '@/backend/model/TerminologyServerCredential'
+import { getGrouperLibrary, getGrouperValuesets } from '@/helpers/server/serverLibraryHelper'
 
 // --------------------------------------------
 // ------------ HELPER FUNCTIONS --------------
@@ -199,7 +200,7 @@ const getLeafFromTermServer = async ({
 // update condition and priority on program
 const updateLeafValueSetVersions = async (req: NextApiRequest, res: NextApiResponse<updateLeafResponse>): Promise<void> => {
   const body = await req.body as HandleVersionChange
-  const { vsCanonical, selectedVersion, grouperIds, programId, terminologyInfo, useContext } = body
+  const { vsCanonical, selectedVersion, grouperIds, programId, terminologyInfo, useContext, previousPinnedCanonical } = body
   // save that particular version valueSet to the HAPI server
   // we must place the conditions & authoritative source on the valueset
 
@@ -270,8 +271,15 @@ const updateLeafValueSetVersions = async (req: NextApiRequest, res: NextApiRespo
       }))
 
     const program = (await FhirClient.getInstance().read({ resourceType: 'Library', id: programId })) as fhir4.Library
+
+    // If more than one grouper membership shares this bare canonical, only an exact pin match
+    // is safe. Otherwise, a bare url match is fine.
+    const grouperLibrary = await getGrouperLibrary(program)
+    const allGrouperValueSets = await getGrouperValuesets(grouperLibrary)
+    const isAmbiguous = countDistinctPinsForCanonical(allGrouperValueSets, vsCanonical) > 1
+
     program.relatedArtifact?.forEach((i) => {
-      if (i?.resource?.split('|')?.[0] === vsCanonical) {
+      if (isDependsOnEntryForLeaf({ entryResource: i?.resource, previousPinnedCanonical, vsCanonical, isAmbiguous })) {
         i.resource = selectedVersion === 'latest' ? vsCanonical : `${vsCanonical}|${selectedVersion}`
       }
     })

--- a/vsm-app/tests/api/programs/[id]/details/valuesets/index.spec.ts
+++ b/vsm-app/tests/api/programs/[id]/details/valuesets/index.spec.ts
@@ -1,0 +1,61 @@
+import { getProgramDetailsValuesets } from '@/pages/api/programs/[id]/details/valuesets'
+import { getProgram, getGrouperLibrary, getGrouperValuesets } from '@/helpers/server/serverLibraryHelper'
+import { fetchLeafValueSets } from '@/helpers/server/serverValueSetHelper'
+
+// jest.mock needs a resolvable relative path here - the @/ alias isn't picked up by
+// babel-plugin-jest-hoist in this project's jest config, even though normal imports work with it
+jest.mock('../../../../../../helpers/server/serverLibraryHelper')
+jest.mock('../../../../../../helpers/server/serverValueSetHelper')
+
+describe('/api/programs/[id]/details/valuesets', () => {
+  describe('getProgramDetailsValuesets', () => {
+    const bareUrl = 'http://example.com/ValueSet/foo'
+
+    beforeEach(() => {
+      jest.resetAllMocks()
+      ;(getProgram as jest.Mock).mockResolvedValue({ resourceType: 'Library', id: 'program-1', name: 'Program 1' })
+      ;(getGrouperLibrary as jest.Mock).mockResolvedValue({ resourceType: 'Library', id: 'grouper-lib' })
+      // one grouper (dxtc) includes the pinned canonical, a different grouper (sdtc) includes
+      // the unpinned canonical for the same bare url
+      ;(getGrouperValuesets as jest.Mock).mockResolvedValue([
+        {
+          resourceType: 'ValueSet',
+          id: 'dxtc',
+          url: 'http://example.com/ValueSet/dxtc',
+          title: 'dxtc',
+          compose: { include: [{ valueSet: [`${bareUrl}|1.0`] }] }
+        },
+        {
+          resourceType: 'ValueSet',
+          id: 'sdtc',
+          url: 'http://example.com/ValueSet/sdtc',
+          title: 'sdtc',
+          compose: { include: [{ valueSet: [bareUrl] }] }
+        }
+      ])
+      ;(fetchLeafValueSets as jest.Mock).mockResolvedValue([
+        { resourceType: 'ValueSet', id: 'foo-pinned', url: bareUrl, version: '1.0', pinnedCanonical: `${bareUrl}|1.0` },
+        { resourceType: 'ValueSet', id: 'foo-unpinned', url: bareUrl, version: 'latest', pinnedCanonical: bareUrl }
+      ])
+    })
+
+    it('keeps grouper membership and pinned version independent for a pinned and unpinned row sharing the same bare url', async () => {
+      const { status, payload } = (await getProgramDetailsValuesets({ id: 'program-1' })) as any
+
+      expect(status).toBe(200)
+      expect(payload.data).toHaveLength(2)
+
+      const pinnedRow = payload.data.find((row: any) => row.valueSet.id === 'foo-pinned')
+      const unpinnedRow = payload.data.find((row: any) => row.valueSet.id === 'foo-unpinned')
+
+      // the pinned row only belongs to dxtc (the grouper that actually composes the pinned canonical)
+      expect(pinnedRow.groups?.map((g: any) => g.id)).toStrictEqual(['dxtc'])
+      expect(pinnedRow.valueSetPinnedVersion).toBe('1.0')
+
+      // the unpinned row only belongs to sdtc, and has no pinned version - it must not inherit
+      // dxtc's membership or pin just because it shares the same bare ValueSet.url
+      expect(unpinnedRow.groups?.map((g: any) => g.id)).toStrictEqual(['sdtc'])
+      expect(unpinnedRow.valueSetPinnedVersion).toBeUndefined()
+    })
+  })
+})

--- a/vsm-app/types/valuesets.ts
+++ b/vsm-app/types/valuesets.ts
@@ -45,4 +45,6 @@ export interface TableRow {
   valueSet: fhir4.ValueSet
   groups: GroupItem[]
   valueSetPinnedVersion?: string
+  // the canonical (url, or url|version) this row was resolved from distinguishes distinct versions for the same url
+  pinnedCanonical?: string
 }


### PR DESCRIPTION
A program's ValueSet table showed merged/wrong grouper membership, pinned version, and condition/priority data whenever the same ValueSet canonical url appeared twice - once pinned to a version, once unpinned (or pinned differently via two different groupers).

This occurred because those joins were all keyed by the bare 'ValueSet.url', which both rows share, instead of the exact pinned canonical ('url' or 'url|version') each row actually represents.

A related bug in the per-row version re-pin flow could corrupt this further: re-pinning a leaf's 'depends-on' relatedArtifact  (which carries its condition/priority) to a new pin matched by bare url only, so re-pinning one grouper membership could silently overwrite another rows priority/condition data when both shared a bare canonical.

Fixed by keying the relevant joins/lookups by the exact pinned canonical, with a bare url fallback kept only where it's safe to do so (unambiguous canonicals, and the code search lookup that has no version to key on).

Added & updated unit tests to verify behaviour and an integration style test directly covering the pinned/unpinned collision scenario.

Manually verified behaviour via VSM workflow.