### PR TITLE
VSP ID now includes IG version

### DIFF
--- a/vsm-app/helpers/vspHelpers.spec.ts
+++ b/vsm-app/helpers/vspHelpers.spec.ts
@@ -51,17 +51,22 @@ describe('vspHelpers', () => {
   })
 
   describe('constructVSPId', () => {
-    it('should build a correct VSP ID', () => {
-      expect(constructVSPId('hl7.fhir.us.core', '2026-01')).toBe('hl7.fhir.us.core-vsp-2026-01')
+    it('should build a correct VSP ID including the IG version', () => {
+      expect(constructVSPId('hl7.fhir.us.core', '6.1.0', '2026-01')).toBe('hl7.fhir.us.core.6.1.0-2026-01')
     })
 
     it('should handle different package IDs and versions', () => {
-      expect(constructVSPId('hl7.fhir.us.ecr', '2025-06')).toBe('hl7.fhir.us.ecr-vsp-2025-06')
+      expect(constructVSPId('hl7.fhir.us.ecr', '2.1.0', '2025-06')).toBe('hl7.fhir.us.ecr.2.1.0-2025-06')
     })
 
     it('should include the full version string', () => {
-      const id = constructVSPId('some.package', '2030-12')
-      expect(id).toBe('some.package-vsp-2030-12')
+      const id = constructVSPId('some.package', '1.0.0', '2030-12')
+      expect(id).toBe('some.package.1.0.0-2030-12')
+    })
+
+    it('should produce distinct IDs for different IG versions with the same VSP version (issue #700)', () => {
+      expect(constructVSPId('hl7.fhir.us.core', '6.1.0', '2026-06'))
+        .not.toBe(constructVSPId('hl7.fhir.us.core', '6.2.0', '2026-06'))
     })
   })
 

--- a/vsm-app/helpers/vspHelpers.ts
+++ b/vsm-app/helpers/vspHelpers.ts
@@ -33,14 +33,16 @@ export const constructVSPUrl = (igMetadata: VSPMetadata): string => {
  * constructVSPId: Builds the FHIR resource ID for a VSP Library
  *
  * Why needed: FHIR resource IDs must be unique and follow a convention.
- * The ID is used to reference the resource in URLs and searches.
+ * The ID must include the IG version so that packages for different IG
+ * versions that share the same VSP version (date) don't collide (issue #700).
  *
- * Example: "hl7.fhir.us.core" + "2026-01" → "hl7.fhir.us.core-vsp-2026-01"
+ * Example: "hl7.fhir.us.core" + "6.1.0" + "2026-01" → "hl7.fhir.us.core.6.1.0-2026-01"
  *
- * Why this pattern: Ensures uniqueness by combining package ID and version
+ * Why this pattern: {igPackageId}.{igVersion}-{vspVersion} ensures uniqueness
+ * across both IG versions and VSP versions.
  */
-export const constructVSPId = (igPackageId: string, vspVersion: string): string => {
-  return `${igPackageId}-vsp-${vspVersion}`
+export const constructVSPId = (igPackageId: string, igVersion: string, vspVersion: string): string => {
+  return `${igPackageId}.${igVersion}-${vspVersion}`
 }
 
 /**

--- a/vsm-app/pages/api/value-set-packages/create.ts
+++ b/vsm-app/pages/api/value-set-packages/create.ts
@@ -41,7 +41,7 @@ const createVSP = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Construct VSP URL and ID
     const vspUrl = constructVSPUrl(vspMetadata)
-    const vspId = constructVSPId(body.igPackageId, body.vspVersion)
+    const vspId = constructVSPId(body.igPackageId, igVersion, body.vspVersion)
 
     Logger.getLogger().info(`Constructed VSP URL: ${vspUrl}`)
     Logger.getLogger().info(`Constructed VSP ID: ${vspId}`)

--- a/vsm-app/tests/api/value-set-packages/create.spec.ts
+++ b/vsm-app/tests/api/value-set-packages/create.spec.ts
@@ -26,7 +26,7 @@ describe('/api/value-set-packages/create', () => {
     })
     FhirClient.getInstance().update = jest.fn().mockResolvedValue({
       resourceType: 'Library',
-      id: 'hl7.fhir.us.core-vsp-2026-01'
+      id: 'hl7.fhir.us.core.6.1.0-2026-01'
     })
   })
 
@@ -40,7 +40,7 @@ describe('/api/value-set-packages/create', () => {
     expect(res._getStatusCode()).toBe(201)
 
     const data = JSON.parse(res._getData())
-    expect(data.vspId).toBe('hl7.fhir.us.core-vsp-2026-01')
+    expect(data.vspId).toBe('hl7.fhir.us.core.6.1.0-2026-01')
     expect(data.message).toContain('successfully')
   })
 
@@ -55,7 +55,7 @@ describe('/api/value-set-packages/create', () => {
     expect(FhirClient.getInstance().update).toHaveBeenCalledWith(
       expect.objectContaining({
         resourceType: 'Library',
-        id: 'hl7.fhir.us.core-vsp-2026-01',
+        id: 'hl7.fhir.us.core.6.1.0-2026-01',
         body: expect.objectContaining({
           resourceType: 'Library',
           status: 'draft',
@@ -134,7 +134,7 @@ describe('/api/value-set-packages/create', () => {
     // Read succeeds = VSP already exists
     FhirClient.getInstance().read = jest.fn().mockResolvedValue({
       resourceType: 'Library',
-      id: 'hl7.fhir.us.core-vsp-2026-01'
+      id: 'hl7.fhir.us.core.6.1.0-2026-01'
     })
 
     const { req, res } = createMocks({


### PR DESCRIPTION
Value Set Package IDs were generated as {igPackageId}-vsp-{vspVersion}, omitting the version. Creating packages for the same date against different versions (e.g. hl7.fhir.us.core|6.1.0 and |6.2.0, both 2026-06) produced identical IDs and clashed.

Now including the version as {igPackageId}.{igVersion}-{vspVersion} (e.g. hl7.fhir.us.core.6.1.0-2026-01). Added a regression test verifying different versions with the same VSP version yield distinct IDs.

Closes #700 