### PR TITLE
Fix data corruption issue and temporarily disable ValueSet Library & PlanDef Sheet generation

### DIFF
--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -73,6 +73,12 @@ const collector = (input: any) => {
 }
 
 /**
+ * Builds a table name Excel will accept. Grouper ids look like "dxtc-3.2.2", this logic converts the hyphen and periods
+ * to underscores to ensure the table name is valid.
+ */
+const toTableName = (prefix: string, id: string) => `${prefix}_${String(id ?? '').replaceAll(/\W/g, '_')}`
+
+/**
  * Autosorts the table based on the content of the rows. Not recommended to use this more than once per sheet.
  * Doing so will distort the rows for other tables.
  * @param table
@@ -433,7 +439,7 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
         groungListTableTitle.value = 'Grouping List'
         groungListTableTitle.font = { bold: true, color: { argb: 'FF0000FF' } }
         const groupingListTable = groupingValueSetSheet.addTable({
-          name: 'valueset_groupinglist_' + currentId,
+          name: toTableName('valueset_groupinglist', currentId),
           ref: `A${groupingTableStartRowCount + 1}`,
           headerRow: true,
           style: {},
@@ -477,7 +483,7 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
         tableTitle.value = 'Code List'
         tableTitle.font = { bold: true, color: { argb: 'FF0000FF' } }
         const table = groupingValueSetSheet.addTable({
-          name: 'valueset_codelist_' + currentId,
+          name: toTableName('valueset_codelist', currentId),
           ref: `A${codeRowsStartRowCount + 1}`,
           headerRow: true,
           style: {},

--- a/vsm-app/pages/api/programs/[id]/compare.ts
+++ b/vsm-app/pages/api/programs/[id]/compare.ts
@@ -39,15 +39,15 @@ const downloadChangeLog = async (req: NextApiRequest, res: NextApiResponse): Pro
 
   const sourceGrouperLibrary = (await getGrouperLibrary(sourceLibrary)) as fhir4.Library
   const targetGrouperLibrary = (await getGrouperLibrary(targetLibrary)) as fhir4.Library
-  const grouperLibDiffJson = changeJson.pages.filter(
+/*  const grouperLibDiffJson = changeJson.pages.filter(
     (page: any) => page.resourceType === 'Library' && page.url === targetGrouperLibrary.url
-  )?.[0]
+  )?.[0]*/
 
   const groupingValueSetsChangeLogs = changeJson.pages.filter((page: any) => page.resourceType === 'ValueSet')
 
   generateReadMeSheet(workbook, sourceGrouperLibrary, targetGrouperLibrary, changeJson.pages[0])
-  generatePlanDefSheet(workbook, changeJson.pages.filter((page: any) => page.resourceType === 'PlanDefinition')?.[0])
-  generateRCTCSheet(workbook, targetGrouperLibrary, grouperLibDiffJson)
+  //generatePlanDefSheet(workbook, changeJson.pages.filter((page: any) => page.resourceType === 'PlanDefinition')?.[0])
+  //generateRCTCSheet(workbook, targetGrouperLibrary, grouperLibDiffJson)
 
   await generateGrouperValuesetSheet(workbook, groupingValueSetsChangeLogs)
 

--- a/vsm-app/pages/api/programs/[id]/compare.ts
+++ b/vsm-app/pages/api/programs/[id]/compare.ts
@@ -46,6 +46,7 @@ const downloadChangeLog = async (req: NextApiRequest, res: NextApiResponse): Pro
   const groupingValueSetsChangeLogs = changeJson.pages.filter((page: any) => page.resourceType === 'ValueSet')
 
   generateReadMeSheet(workbook, sourceGrouperLibrary, targetGrouperLibrary, changeJson.pages[0])
+  //TODO:: Resolve issues with diff for these sheets and restore generation. See:https://alphora.atlassian.net/browse/APHL-1428
   //generatePlanDefSheet(workbook, changeJson.pages.filter((page: any) => page.resourceType === 'PlanDefinition')?.[0])
   //generateRCTCSheet(workbook, targetGrouperLibrary, grouperLibDiffJson)
 


### PR DESCRIPTION
Grouper data table names were using grouper IDs, which contained hyphens and periods. These invalid table name characters were causing data corruption errors on opening the workbooks. Replace these characters with underscores.

Temporarily disable generation of the ValueSet Library and PlanDef sheets. They require further refinement and are not essential right now. 