### PR TITLE
Ensure Changelog ValueSet 'replace' entries are rendered in UI & Sheet

### DIFF
--- a/vsm-app/helpers/createTables.spec.ts
+++ b/vsm-app/helpers/createTables.spec.ts
@@ -332,4 +332,70 @@ describe('createTableData', () => {
     expect(result.grouperPages).toStrictEqual(expectedGrouperData)
   })
 
+  it('should label a leaf whose grouper reference was repinned to a new version', () => {
+    const leaf = {
+      url: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.277',
+      title: 'Haemophilus influenzae',
+      status: 'active',
+      name: 'HaemophilusInfluenzae',
+      memberOid: '2.16.840.1.113762.1.4.1146.277',
+      priority: { value: 'routine' },
+      conditions: [],
+      codeSystems: [{ name: 'LOINC', oid: '2.16.840.1.113883.6.1' }]
+    }
+    const withRepin = JSON.parse(JSON.stringify(changelog))
+    const grouperPage = withRepin.pages.find((p: any) => p?.newData?.resourceType === 'ValueSet')
+    grouperPage.oldData.leafValueSets = [{ ...leaf }]
+    grouperPage.newData.leafValueSets = [{
+      ...leaf,
+      operation: {
+        type: 'replace',
+        path: 'ValueSet.compose.include[0].valueSet[0]',
+        oldValue: `${leaf.url}|20240619`
+      }
+    }]
+
+    const result = createTableData(withRepin)
+    // @ts-ignore
+    const grouper = result.grouperPages[0]
+    const row = grouper.valueSetsTable.find((r: any) => r.oid === leaf.memberOid)
+
+    expect(row).toBeDefined()
+    expect(row!.change).toBe('Updated VS Version')
+    // an empty change string is what hid the row, so the section has to know it changed
+    expect(grouper.hasChanges).toBe(true)
+  })
+
+  // guards the ordering of the branch - a repin must not shadow the existing labels
+  it('should keep condition and priority labels ahead of the repin label', () => {
+    const leaf = {
+      url: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.277',
+      title: 'Haemophilus influenzae',
+      status: 'active',
+      name: 'HaemophilusInfluenzae',
+      memberOid: '2.16.840.1.113762.1.4.1146.277',
+      priority: { value: 'routine' },
+      conditions: [{
+        code: '840539006',
+        codeSystemName: 'SNOMEDCT',
+        codeSystemOid: '2.16.840.1.113883.6.96',
+        display: 'COVID-19',
+        system: 'http://snomed.info/sct',
+        operation: { type: 'replace', path: 'ValueSet.useContext[0]' }
+      }],
+      codeSystems: [],
+      operation: { type: 'replace', path: 'ValueSet.compose.include[0].valueSet[0]' }
+    }
+    const withBoth = JSON.parse(JSON.stringify(changelog))
+    const grouperPage = withBoth.pages.find((p: any) => p?.newData?.resourceType === 'ValueSet')
+    grouperPage.oldData.leafValueSets = [{ ...leaf, conditions: [], operation: undefined }]
+    grouperPage.newData.leafValueSets = [leaf]
+
+    const result = createTableData(withBoth)
+    // @ts-ignore
+    const row = result.grouperPages[0].valueSetsTable.find((r: any) => r.oid === leaf.memberOid)
+
+    expect(row!.change).toBe('Update Conditions')
+  })
+
 })

--- a/vsm-app/helpers/createTables.spec.ts
+++ b/vsm-app/helpers/createTables.spec.ts
@@ -366,6 +366,32 @@ describe('createTableData', () => {
     expect(grouper.hasChanges).toBe(true)
   })
 
+  // A full compose replace tags every leaf in the grouper, not just the ones that moved, so
+  // the label must not claim a version change unless the operation is on the leaf's own reference.
+  it('should not claim a version change for a replace outside the leaf reference', () => {
+    const leaf = {
+      url: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.277',
+      title: 'Haemophilus influenzae',
+      status: 'active',
+      name: 'HaemophilusInfluenzae',
+      memberOid: '2.16.840.1.113762.1.4.1146.277',
+      priority: { value: 'routine' },
+      conditions: [],
+      codeSystems: [],
+      operation: { type: 'replace', path: 'ValueSet.compose' }
+    }
+    const withComposeReplace = JSON.parse(JSON.stringify(changelog))
+    const grouperPage = withComposeReplace.pages.find((p: any) => p?.newData?.resourceType === 'ValueSet')
+    grouperPage.oldData.leafValueSets = [{ ...leaf, operation: undefined }]
+    grouperPage.newData.leafValueSets = [leaf]
+
+    const result = createTableData(withComposeReplace)
+    // @ts-ignore
+    const row = result.grouperPages[0].valueSetsTable.find((r: any) => r.oid === leaf.memberOid)
+
+    expect(row!.change).toBe('Updated VS')
+  })
+
   // guards the ordering of the branch - a repin must not shadow the existing labels
   it('should keep condition and priority labels ahead of the repin label', () => {
     const leaf = {

--- a/vsm-app/helpers/createTables.ts
+++ b/vsm-app/helpers/createTables.ts
@@ -164,6 +164,9 @@ const generateMainChangeText = (grouperListItem: any) => {
     return `${allConditionChangeTypes[0]} Conditions`
   } else if (grouperListItem?.priority?.operation) {
     return 'Updated Priority'
+  } else if (grouperListItem?.operation?.type === 'replace') {
+    // the grouper's compose reference to this leaf was repinned to a different version.
+    return 'Updated VS Version'
   } else {
     return '' // ?
   }

--- a/vsm-app/helpers/createTables.ts
+++ b/vsm-app/helpers/createTables.ts
@@ -165,8 +165,10 @@ const generateMainChangeText = (grouperListItem: any) => {
   } else if (grouperListItem?.priority?.operation) {
     return 'Updated Priority'
   } else if (grouperListItem?.operation?.type === 'replace') {
-    // the grouper's compose reference to this leaf was repinned to a different version.
-    return 'Updated VS Version'
+    // Only an operation on a compose elements specific leaf's reference tells us the pin moved. A full
+    // compose element replace tags every leaf in the grouper, so fall back to a generic label
+    // there rather than claiming a version change.
+    return grouperListItem?.operation?.path?.includes('.valueSet') ? 'Updated VS Version' : 'Updated VS'
   } else {
     return '' // ?
   }

--- a/vsm-app/helpers/exportExcelHelper.spec.ts
+++ b/vsm-app/helpers/exportExcelHelper.spec.ts
@@ -1,6 +1,11 @@
 jest.mock('undici', () => ({ fetch: jest.fn(), Agent: jest.fn() }))
+// relative paths here: jest.config.js only maps the @/components and @/pages aliases
+jest.mock('../backend/clients/FhirCdrClient', () => ({ __esModule: true, default: { getInstance: () => ({ baseUrl: 'http://test/fhir' }) } }))
+jest.mock('./server/serverValueSetHelper', () => ({ fetchByCanonical: jest.fn() }))
 
-import { buildChangeRows, collector, mergeChanges } from './exportExcelHelper'
+import ExcelJS from 'exceljs'
+import { fetchByCanonical } from './server/serverValueSetHelper'
+import { buildChangeRows, collector, generateGrouperValuesetSheet, mergeChanges } from './exportExcelHelper'
 
 // Shapes mirror a $create-changelog Library page: relatedArtifacts entries carry the canonical in
 // `value`, and Page routes each operation type to oldData, newData, or (for replace) both.
@@ -134,5 +139,121 @@ describe('buildChangeRows', () => {
     )
 
     rows.flat().forEach((cell) => expect(typeof cell === 'string' || cell === '').toBe(true))
+  })
+})
+
+describe('generateGrouperValuesetSheet', () => {
+  const grouperVs = {
+    resourceType: 'ValueSet',
+    name: 'DiagnosisProblemTriggers',
+    status: 'active',
+    version: '3.6.2',
+    publisher: 'CSTE Steward',
+    purpose: 'Diagnoses or problems documented in a clinical record.',
+    description: 'Purpose: Clinical Focus',
+    identifier: [{ value: 'urn:oid:2.16.840.1.113762.1.4.1146.627' }]
+  }
+
+  // A repinned leaf: the grouper's compose reference moved to a new version. The leaf itself
+  // carries the replace and has no conditions, which used to emit no rows at all.
+  // Page records a replace on BOTH sides, so oldData carries the same leaf under its old name.
+  const pageWithRepinnedLeaf = (conditions: any[]) => ({
+    resourceType: 'ValueSet',
+    url: 'http://ersd.aimsplatform.org/fhir/ValueSet/dxtc',
+    oldData: {
+      resourceType: 'ValueSet',
+      id: { value: '10' },
+      version: { value: '3.6.1' },
+      title: { value: 'Diagnosis_Problem Triggers for Public Health Reporting' },
+      leafValueSets: [
+        {
+          name: 'Diptheria Disorders',
+          memberOid: '2.16.840.1.113762.1.4.1146.6',
+          status: 'active',
+          priority: { value: 'routine' },
+          codeSystems: [{ name: 'SNOMEDCT', oid: '2.16.840.1.113883.6.96' }],
+          conditions,
+          operation: { type: 'replace', path: 'ValueSet.compose.include[0].valueSet[0]', newValue: 'dxtc|3.6.2' }
+        }
+      ],
+      codes: []
+    },
+    newData: {
+      resourceType: 'ValueSet',
+      id: { value: '10' },
+      version: { value: '3.6.2' },
+      title: { value: 'Diagnosis_Problem Triggers for Public Health Reporting' },
+      leafValueSets: [
+        {
+          // renamed between versions, as VSAC content does - lets the assertions tell the sides apart
+          name: 'DiphtheriaDisordersSNOMED',
+          memberOid: '2.16.840.1.113762.1.4.1146.6',
+          status: 'active',
+          priority: { value: 'routine' },
+          codeSystems: [{ name: 'SNOMEDCT', oid: '2.16.840.1.113883.6.96' }],
+          conditions,
+          operation: { type: 'replace', path: 'ValueSet.compose.include[0].valueSet[0]' }
+        }
+      ],
+      codes: []
+    }
+  })
+
+  const buildSheet = async (conditions: any[]) => {
+    ;(fetchByCanonical as jest.Mock).mockResolvedValue({ entry: [{ resource: grouperVs }] })
+    const workbook = new ExcelJS.Workbook()
+    await generateGrouperValuesetSheet(workbook, [pageWithRepinnedLeaf(conditions)])
+    return workbook.getWorksheet(grouperVs.name)!
+  }
+
+  const groupingRows = (sheet: ExcelJS.Worksheet) => {
+    const rows: any[][] = []
+    sheet.eachRow((row) => {
+      const values = (row.values as any[]).slice(1)
+      if (values[1] === '2.16.840.1.113762.1.4.1146.6') { rows.push(values) }
+    })
+    return rows
+  }
+
+  it('emits a Grouping List row for a leaf that changed but has no conditions', async () => {
+    const sheet = await buildSheet([])
+    const titles: string[] = []
+    sheet.eachRow((row) => { const v = (row.values as any[])[1]; if (typeof v === 'string') titles.push(v) })
+
+    expect(titles).toContain('Grouping List')
+    const rows = groupingRows(sheet)
+    // one row for the leaf, not one per side of the replace
+    expect(rows).toHaveLength(1)
+    // the Change column is last, and blank condition columns sit before it
+    expect(rows[0][rows[0].length - 1]).toBe('replace')
+    // newData's name, matching what the Value Sets table shows on screen
+    expect(rows[0][0]).toBe('DiphtheriaDisordersSNOMED')
+  })
+
+  it('keeps a leaf that only exists in oldData, so removals are not lost', async () => {
+    ;(fetchByCanonical as jest.Mock).mockResolvedValue({ entry: [{ resource: grouperVs }] })
+    const page: any = pageWithRepinnedLeaf([])
+    page.newData.leafValueSets = []
+    page.oldData.leafValueSets[0].operation = { type: 'delete', path: 'ValueSet.compose.include[0].valueSet[0]' }
+
+    const workbook = new ExcelJS.Workbook()
+    await generateGrouperValuesetSheet(workbook, [page])
+    const rows = groupingRows(workbook.getWorksheet(grouperVs.name)!)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0][0]).toBe('Diptheria Disorders')
+    expect(rows[0][rows[0].length - 1]).toBe('delete')
+  })
+
+  it('still emits one row per condition when the leaf has them', async () => {
+    const sheet = await buildSheet([
+      { code: '840539006', display: 'COVID-19', system: 'http://snomed.info/sct', codeSystemName: 'SNOMEDCT', version: '2025-09' },
+      { code: '27836007', display: 'Pertussis', system: 'http://snomed.info/sct', codeSystemName: 'SNOMEDCT', version: '2025-09' }
+    ])
+
+    const rows = groupingRows(sheet)
+    expect(rows).toHaveLength(2)
+    expect(rows.map((r) => r[6])).toStrictEqual(['COVID-19', 'Pertussis'])
+    rows.forEach((r) => expect(r[r.length - 1]).toBe('replace'))
   })
 })

--- a/vsm-app/helpers/exportExcelHelper.spec.ts
+++ b/vsm-app/helpers/exportExcelHelper.spec.ts
@@ -230,6 +230,23 @@ describe('generateGrouperValuesetSheet', () => {
     expect(rows[0][0]).toBe('DiphtheriaDisordersSNOMED')
   })
 
+  // The same OID can carry different change types on each side e.g. a reordering diff emits a
+  // delete at one index and an insert at another. Only a replace is recorded on both sides, so
+  // only a replace may be collapsed; anything else has to survive the merge.
+  it('keeps both sides when the same OID has different old and new change types', async () => {
+    ;(fetchByCanonical as jest.Mock).mockResolvedValue({ entry: [{ resource: grouperVs }] })
+    const page: any = pageWithRepinnedLeaf([])
+    page.oldData.leafValueSets[0].operation = { type: 'delete', path: 'ValueSet.compose.include[0].valueSet[0]' }
+    page.newData.leafValueSets[0].operation = { type: 'insert', path: 'ValueSet.compose.include[0].valueSet[3]' }
+
+    const workbook = new ExcelJS.Workbook()
+    await generateGrouperValuesetSheet(workbook, [page])
+    const rows = groupingRows(workbook.getWorksheet(grouperVs.name)!)
+
+    expect(rows).toHaveLength(2)
+    expect(rows.map((r) => r[r.length - 1]).sort()).toStrictEqual(['delete', 'insert'])
+  })
+
   it('keeps a leaf that only exists in oldData, so removals are not lost', async () => {
     ;(fetchByCanonical as jest.Mock).mockResolvedValue({ entry: [{ resource: grouperVs }] })
     const page: any = pageWithRepinnedLeaf([])

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -397,11 +397,10 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
       })
 
       // ValueSet CodeSystem Changes
-      // TODO: fix this
       const groupingListRows: any[] = []
 
       const groupingTableStartRowCount = vsInfo.length + 3
-      let conditionsAdded = 0 // Every condition will be a row we need to increment for Code List table start
+      let groupingRowsAdded = 0 // Every grouping row shifts the Code List table start down
       const fillGroupingListTableRows = (data: any) => {
         Object.entries(data).forEach(([key, change]) => {
           // @ts-ignore todo: fix this
@@ -409,9 +408,8 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
             const { conditions, memberOid, name, codeSystems, status, priority } = rowValue
             const vsCodeSystemName = codeSystems?.[0]?.name || ''
             const vsCodeSystemOid = codeSystems?.[0]?.oid || ''
-            conditions?.forEach((condition: any) => {
-              conditionsAdded += 1 // Increment row count
-              const { code, system, version, display, codeSystemName } = condition
+            const pushGroupingRow = (condition?: any) => {
+              groupingRowsAdded += 1
               groupingListRows.push([
                 name,
                 memberOid,
@@ -419,19 +417,38 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
                 vsCodeSystemName,
                 vsCodeSystemOid,
                 status,
-                display,
-                code,
-                codeSystemName,
-                version,
+                condition?.display ?? '',
+                condition?.code ?? '',
+                condition?.codeSystemName ?? '',
+                condition?.version ?? '',
                 key
               ])
-            })
+            }
+            if (conditions?.length) {
+              conditions.forEach((condition: any) => pushGroupingRow(condition))
+            } else {
+              pushGroupingRow()
+            }
           })
         })
       }
-      const oldToMerge = collector(page.oldData?.leafValueSets)
-      const newToMerge = collector(page.newData?.leafValueSets)
-      const leafValueSets = mergeChanges(oldToMerge, newToMerge)
+      // A replace is recorded on both sides of the page, merging old and new emits the same leaf
+      // twice, under its old name and under its new one. The UI reads newData and only
+      // backfills leaves that no longer exist there, do the same here.
+      const newLeafChanges = collector(page.newData?.leafValueSets)
+      const oldLeafChanges = collector(page.oldData?.leafValueSets)
+      const oidsInNewData = new Set(
+        Object.values(newLeafChanges)
+          .flat()
+          .map((leaf: any) => leaf?.memberOid)
+      )
+      const leafValueSets: CollectedChangeMap = { ...newLeafChanges }
+      Object.entries(oldLeafChanges).forEach(([change, leaves]) => {
+        const removedOnly = leaves?.filter((leaf: any) => !oidsInNewData.has(leaf?.memberOid)) ?? []
+        if (removedOnly.length) {
+          leafValueSets[change] = (leafValueSets[change] ?? []).concat(removedOnly)
+        }
+      })
       fillGroupingListTableRows(leafValueSets)
 
       if (groupingListRows.length > 0) {
@@ -477,7 +494,7 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
 
       fillCodeRows(dataCodes)
 
-      const codeRowsStartRowCount = groupingTableStartRowCount + conditionsAdded + 5
+      const codeRowsStartRowCount = groupingTableStartRowCount + groupingRowsAdded + 5
       if (codeRows.length > 0) {
         const tableTitle = groupingValueSetSheet.getCell(`A${codeRowsStartRowCount}`)
         tableTitle.value = 'Code List'

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -482,10 +482,10 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
       const fillCodeRows = (data: CollectedChangeMap) => {
         Object.entries(data).forEach(([key, value]) => {
           value?.forEach((rowValue) => {
-            const { display: descriptor, memberOid, version, codeValue: code, codeSystemName, parentValueSetName } = rowValue
+            const { display: descriptor, memberOid, version, codeValue: code, codeSystemName } = rowValue
             const status = startCase(grouperVs?.status || '')
             const remapInfo = status === 'Active' ? 'No' : 'Yes'
-            codeRows.push([parentValueSetName, memberOid, code, descriptor, codeSystemName, version, status, remapInfo, key])
+            codeRows.push([memberOid, code, descriptor, codeSystemName, version, status, remapInfo, key])
           })
         })
       }
@@ -504,7 +504,6 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
           headerRow: true,
           style: {},
           columns: [
-            { name: 'Name', filterButton: true },
             { name: 'Member OID', filterButton: true },
             { name: 'Code', filterButton: true },
             { name: 'Descriptor', filterButton: true },

--- a/vsm-app/helpers/exportExcelHelper.ts
+++ b/vsm-app/helpers/exportExcelHelper.ts
@@ -432,23 +432,22 @@ const generateGrouperValuesetSheet = async (workbook: ExcelJS.Workbook, grouping
           })
         })
       }
-      // A replace is recorded on both sides of the page, merging old and new emits the same leaf
-      // twice, under its old name and under its new one. The UI reads newData and only
-      // backfills leaves that no longer exist there, do the same here.
-      const newLeafChanges = collector(page.newData?.leafValueSets)
+      // Page records a delete on oldData only and an insert on newData only, but a replace is on both
+      // so merging the two sides emits a replaced leaf twice, under its old and its new name. Drop
+      // only that duplicate half and leave every other change type to mergeChanges.
       const oldLeafChanges = collector(page.oldData?.leafValueSets)
-      const oidsInNewData = new Set(
-        Object.values(newLeafChanges)
-          .flat()
-          .map((leaf: any) => leaf?.memberOid)
+      const newLeafChanges = collector(page.newData?.leafValueSets)
+      const replacedOidsInNewData = new Set(
+        (newLeafChanges[OPERATION_TYPES.REPLACE] ?? []).map((leaf: any) => leaf?.memberOid)
       )
-      const leafValueSets: CollectedChangeMap = { ...newLeafChanges }
+      const oldLeafChangesWithoutDuplicateReplaces: CollectedChangeMap = {}
       Object.entries(oldLeafChanges).forEach(([change, leaves]) => {
-        const removedOnly = leaves?.filter((leaf: any) => !oidsInNewData.has(leaf?.memberOid)) ?? []
-        if (removedOnly.length) {
-          leafValueSets[change] = (leafValueSets[change] ?? []).concat(removedOnly)
-        }
+        oldLeafChangesWithoutDuplicateReplaces[change] =
+          change === OPERATION_TYPES.REPLACE
+            ? (leaves?.filter((leaf: any) => !replacedOidsInNewData.has(leaf?.memberOid)) ?? [])
+            : leaves
       })
+      const leafValueSets = mergeChanges(oldLeafChangesWithoutDuplicateReplaces, newLeafChanges)
       fillGroupingListTableRows(leafValueSets)
 
       if (groupingListRows.length > 0) {


### PR DESCRIPTION
### Changes

1. UI - createTables.ts
generateMainChangeText handled insert and delete on a leaf but not replace, so a version re-pin was treated as unchanged. Added a replace branch returning 'Updated VS Version'.

2. Sheet - exportExcelHelper.ts:405
fillGroupingListTableRows pushed rows only inside conditions?.forEach, so a leaf with no conditions produced none and the whole Grouping List table vanished. Row now belongs to the leaf, with condition columns blank when they are not included in the changelog data.

3. Sheet - exportExcelHelper.ts:439
mergeChanges concatenated both sides and a replace is recorded on both, so the leaf appeared twice under its old and new names. We now dedupe the replace entries, before running mergeChanges to ensure a single entry for 'replace' changes.

Tests included, and validated by local testing also.